### PR TITLE
容器镜像支持arm64

### DIFF
--- a/.github/workflows/maven-test.yml
+++ b/.github/workflows/maven-test.yml
@@ -26,6 +26,10 @@ jobs:
           bash ./package.sh
           version=$(cat pom.xml | grep -oPm1 '(?<=<version>).*?(?=</version>)')
           echo "version=v$version" >> $GITHUB_ENV
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
       - name: Login to Docker Hub
         uses: docker/login-action@v3
         with:
@@ -36,6 +40,7 @@ jobs:
         with:
           context: ./
           file: ./docker/Dockerfile.tpl
+          platforms: linux/amd64,linux/arm64
           push: true
           tags: wushuo894/ani-rss:test
       - name: DockerHub Description

--- a/.github/workflows/maven-test.yml
+++ b/.github/workflows/maven-test.yml
@@ -14,9 +14,9 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: Set up JDK 11
-        uses: actions/setup-java@v3
+        uses: actions/setup-java@v4
         with:
           java-version: '11'
           distribution: 'temurin'
@@ -27,19 +27,19 @@ jobs:
           version=$(cat pom.xml | grep -oPm1 '(?<=<version>).*?(?=</version>)')
           echo "version=v$version" >> $GITHUB_ENV
       - name: Login to Docker Hub
-        uses: docker/login-action@v2
+        uses: docker/login-action@v3
         with:
           username: ${{ secrets.DOCKER_USERNAME }}
           password: ${{ secrets.DOCKER_PASSWORD }}
       - name: Build and push Docker image
-        uses: docker/build-push-action@v2
+        uses: docker/build-push-action@v6
         with:
           context: ./
           file: ./docker/Dockerfile.tpl
           push: true
           tags: wushuo894/ani-rss:test
       - name: DockerHub Description
-        uses: peter-evans/dockerhub-description@v4.0.0
+        uses: peter-evans/dockerhub-description@v4
         env:
           DOCKERHUB_USERNAME: ${{ secrets.DOCKER_USERNAME }}
           DOCKERHUB_PASSWORD: ${{ secrets.DOCKER_PASSWORD }}

--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -36,6 +36,10 @@ jobs:
           token: ${{ secrets.GITHUB_TOKEN }}
           files: |
             ./target/ani-rss-jar-with-dependencies.jar
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
       - name: Login to Docker Hub
         uses: docker/login-action@v3
         with:
@@ -46,6 +50,7 @@ jobs:
         with:
           context: ./
           file: ./docker/Dockerfile.tpl
+          platforms: linux/amd64,linux/arm64
           push: true
           tags: wushuo894/ani-rss:latest
       - name: DockerHub Description

--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -14,9 +14,9 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: Set up JDK 11
-        uses: actions/setup-java@v3
+        uses: actions/setup-java@v4
         with:
           java-version: '11'
           distribution: 'temurin'
@@ -27,7 +27,7 @@ jobs:
           version=$(cat pom.xml | grep -oPm1 '(?<=<version>).*?(?=</version>)')
           echo "version=v$version" >> $GITHUB_ENV
       - name: Release
-        uses: softprops/action-gh-release@v1
+        uses: softprops/action-gh-release@v2
         with:
           name: ${{ env.version }}
           body_path: UPDATE.md
@@ -37,19 +37,19 @@ jobs:
           files: |
             ./target/ani-rss-jar-with-dependencies.jar
       - name: Login to Docker Hub
-        uses: docker/login-action@v2
+        uses: docker/login-action@v3
         with:
           username: ${{ secrets.DOCKER_USERNAME }}
           password: ${{ secrets.DOCKER_PASSWORD }}
       - name: Build and push Docker image
-        uses: docker/build-push-action@v2
+        uses: docker/build-push-action@v6
         with:
           context: ./
           file: ./docker/Dockerfile.tpl
           push: true
           tags: wushuo894/ani-rss:latest
       - name: DockerHub Description
-        uses: peter-evans/dockerhub-description@v4.0.0
+        uses: peter-evans/dockerhub-description@v4
         env:
           DOCKERHUB_USERNAME: ${{ secrets.DOCKER_USERNAME }}
           DOCKERHUB_PASSWORD: ${{ secrets.DOCKER_PASSWORD }}

--- a/.github/workflows/native.yml
+++ b/.github/workflows/native.yml
@@ -28,7 +28,7 @@ jobs:
           bash ./native-package.sh
           tar czf ani-rss.tar.gz ./target/ani-rss
       - name: Release
-        uses: softprops/action-gh-release@v1
+        uses: softprops/action-gh-release@v2
         with:
           name: ${{ env.version }}
           body_path: UPDATE.md
@@ -38,19 +38,19 @@ jobs:
           files: |
             ./ani-rss.tar.gz
       - name: Login to Docker Hub
-        uses: docker/login-action@v2
+        uses: docker/login-action@v3
         with:
           username: ${{ secrets.DOCKER_USERNAME }}
           password: ${{ secrets.DOCKER_PASSWORD }}
       - name: Build and push Docker image
-        uses: docker/build-push-action@v2
+        uses: docker/build-push-action@v6
         with:
           context: ./
           file: ./docker/Dockerfile-native.tpl
           push: true
           tags: wushuo894/ani-rss-native:latest
       - name: DockerHub Description
-        uses: peter-evans/dockerhub-description@v4.0.0
+        uses: peter-evans/dockerhub-description@v4
         env:
           DOCKERHUB_USERNAME: ${{ secrets.DOCKER_USERNAME }}
           DOCKERHUB_PASSWORD: ${{ secrets.DOCKER_PASSWORD }}

--- a/.github/workflows/native.yml
+++ b/.github/workflows/native.yml
@@ -15,10 +15,16 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+      - uses: graalvm/setup-graalvm@v1
+        with:
+          version: '17.0.9'
+          java-version: '17'
+          distribution: 'graalvm-community'
+          components: 'native-image'
+          github-token: ${{ secrets.GITHUB_TOKEN }}
       - name: Build with Maven
         run: |
           sudo apt update
-          sudo apt install gcc libc6-dev zlib1g-dev
           sudo apt install make curl wget
           version=$(cat pom.xml | grep -oPm1 '(?<=<version>).*?(?=</version>)')
           echo "version=v$version" >> $GITHUB_ENV

--- a/native-package.sh
+++ b/native-package.sh
@@ -1,8 +1,4 @@
 #!/bin/bash
-wget https://github.com/graalvm/graalvm-ce-builds/releases/download/jdk-17.0.9/graalvm-community-jdk-17.0.9_linux-x64_bin.tar.gz
-
-tar -xvf graalvm-community-jdk-17.0.9_linux-x64_bin.tar.gz
-export PATH="$PATH:/home/runner/work/ani-rss/ani-rss/graalvm-community-openjdk-17.0.9+9.1/bin"
 
 mkdir target
 native-image -H:+StaticExecutableWithDynamicLibC -march=compatibility -cp ./ani-rss-jar-with-dependencies.jar ani.rss.Main -o target/ani-rss --no-fallback


### PR DESCRIPTION

![image](https://github.com/user-attachments/assets/ae3fcea4-d028-44a1-8d35-310f59733f5b)


更新了actions版本，应该不会有警告了。

docker镜像现在支持arm64了。

用action安装graalvm，可惜不能编译arm64可执行文件。

https://github.com/marketplace/actions/github-action-for-graalvm#key-features

https://github.blog/changelog/2024-09-03-github-actions-arm64-linux-and-windows-runners-are-now-generally-available/

---

大概能跑起来（