### PR TITLE
支持通过环境变量配置自动更新

### DIFF
--- a/docker/Dockerfile.tpl
+++ b/docker/Dockerfile.tpl
@@ -3,10 +3,11 @@ COPY docker/run.sh /run.sh
 COPY target/ani-rss-jar-with-dependencies.jar /usr/app/ani-rss-jar-with-dependencies.jar
 WORKDIR /usr/app
 VOLUME /config
-ENV PORT="7789"
+ENV PORT=7789
 ENV CONFIG="/config"
 ENV TZ="Asia/Shanghai"
-EXPOSE 7789
+ENV AUTO_UPDATE="false"
+EXPOSE $PORT
 RUN ln -s /opt/java/openjdk /usr/local/openjdk-11
 RUN chmod +x /run.sh
 CMD ["/run.sh"]

--- a/docker/run.sh
+++ b/docker/run.sh
@@ -1,16 +1,17 @@
 #!/bin/bash
 
-port="7789"
+update="$AUTO_UPDATE"
 path="./"
 jar="ani-rss-jar-with-dependencies.jar"
 jar_path=$path$jar
 
-if [ ! -f $jar_path ]; then
+if [ ! -f "$jar_path" ] && [ "$update" ]; then
+    echo "正在更新……"
     version=$(curl -Ls https://github.com/wushuo894/ani-rss/releases/latest | grep -o '<h1 data-view-component="true" class="d-inline mr-3">[^<]*</h1>' | sed 's/<[^>]*>//g')
     url="https://github.com/wushuo894/ani-rss/releases/download/$version/ani-rss-jar-with-dependencies.jar"
-    wget -O $jar_path $url
 
-    if [ $? -eq 0 ]; then
+    if ! wget -O "$jar_path" "$url"
+    then
         echo "$jar_path 下载成功！"
     else
         echo "$jar_path 下载失败。"
@@ -26,8 +27,8 @@ fi
 
 while :
 do
-    java -jar -Xmx2g $jar_path --port $port
-    if [ $? -ne 0 ]; then
+    if ! java -jar -Xmx2g $jar_path --port "$PORT"
+    then
         break
     fi
 done

--- a/docs/docker.md
+++ b/docs/docker.md
@@ -13,11 +13,12 @@
 
 默认 用户名: admin 密码: admin
 
-| 参数     | 作用       | 默认值           |
-|--------|----------|---------------|
-| PORT   | 端口号      | 7789          |
-| CONFIG | 配置文件存放位置 | /config       |
-| TZ     | 时区       | Asia/Shanghai |
+| 参数          | 作用       | 默认值           |
+|-------------|----------|---------------|
+| PORT        | 端口号      | 7789          |
+| CONFIG      | 配置文件存放位置 | /config       |
+| TZ          | 时区       | Asia/Shanghai |
+| AUTO_UPDATE | 自动更新     | false         |
 
 ps: 如果需要开启 文件已下载自动跳过 功能 请确保 qBittorrent 与本程序 docker 映射挂载路径一致
 


### PR DESCRIPTION
默认关闭自动更新。要开启请设置容器环境变量AUTO_UPDATE为true。

Q：为什么要默认关闭？
A：不关闭就没办法固定版本，用户可能不希望在不知情的情况更新，特别是指定了版本号的情况下。另外不是所有环境都能访问github，在校园网等情况下会造成启动卡住的困扰。