### PR TITLE
qb下载配置useDownloadPath配置化

### DIFF
--- a/src/main/java/ani/rss/download/qBittorrent.java
+++ b/src/main/java/ani/rss/download/qBittorrent.java
@@ -83,6 +83,7 @@ public class qBittorrent implements BaseDownload {
         String host = config.getHost();
         Integer renameSleep = config.getRenameSleep();
         Boolean qbRenameTitle = config.getQbRenameTitle();
+        Boolean qbUseDownloadPath = config.getQbUseDownloadPath();
         HttpRequest httpRequest = HttpReq.post(host + "/api/v2/torrents/add", false)
                 .form("addToTopOfQueue", false)
                 .form("autoTMM", false)
@@ -96,7 +97,7 @@ public class qBittorrent implements BaseDownload {
                 .form("skip_checking", false)
                 .form("stopCondition", "None")
                 .form("upLimit", 102400)
-                .form("useDownloadPath", false)
+                .form("useDownloadPath", Boolean.TRUE.equals(qbUseDownloadPath))
                 .form("tags", "ani-rss");
 
         String extName = FileUtil.extName(torrentFile);

--- a/src/main/java/ani/rss/entity/Config.java
+++ b/src/main/java/ani/rss/entity/Config.java
@@ -35,6 +35,11 @@ public class Config implements Serializable {
     private Boolean qbRenameTitle;
 
     /**
+     * qb下载时，使用qb自身的保存路径配置(未下载完成的使用临时目录，复制种子文件)
+     */
+    private Boolean qbUseDownloadPath;
+
+    /**
      * 下载路径
      */
     private String downloadPath;

--- a/src/main/java/ani/rss/util/ConfigUtil.java
+++ b/src/main/java/ani/rss/util/ConfigUtil.java
@@ -46,6 +46,7 @@ public class ConfigUtil {
                 .setUsername("")
                 .setPassword("")
                 .setQbRenameTitle(true)
+                .setQbUseDownloadPath(false)
                 .setSkip5(true)
                 .setDebug(false)
                 .setProxy(false)

--- a/ui/src/config/Download.vue
+++ b/ui/src/config/Download.vue
@@ -77,6 +77,15 @@
     <el-form-item label="修改任务标题">
       <el-switch v-model:model-value="props.config.qbRenameTitle" :disabled="config.download !== 'qBittorrent'"/>
     </el-form-item>
+    <el-form-item label="QB保存路径配置">
+      <div>
+        <el-switch v-model:model-value="props.config.qbUseDownloadPath"></el-switch>
+        <br>
+        <el-text class="mx-1" size="small">
+          开启后将使用qBittorrent的保存路径配置(下载路径不受影响)
+        </el-text>
+      </div>
+    </el-form-item>
   </el-form>
 </template>
 

--- a/ui/src/home/Config.vue
+++ b/ui/src/home/Config.vue
@@ -111,7 +111,8 @@ const config = ref({
   'webHookMethod': '',
   'webHookBody': '',
   'webHook': false,
-  'qbRenameTitle': true
+  'qbRenameTitle': true,
+  'qbUseDownloadPath': false
 })
 
 const activeName = ref('download')


### PR DESCRIPTION
将qb下载配置useDownloadPath配置化，打开后可以使用qb配置的临时下载目录、拷贝种子等功能