### PR TITLE
修改配置时重载页面，修复getList时week不展示的bug

### DIFF
--- a/ui/src/home/App.vue
+++ b/ui/src/home/App.vue
@@ -1,5 +1,5 @@
 <template>
-  <Config ref="config"/>
+  <Config ref="config" @load="list?.getList"/>
   <Add ref="add" @load="list?.getList"/>
   <Logs ref="logs"/>
   <Manage ref="manage" @load="list?.getList"/>

--- a/ui/src/home/Config.vue
+++ b/ui/src/home/Config.vue
@@ -172,6 +172,7 @@ const editConfig = () => {
   api.post('api/config', my_config)
       .then(res => {
         ElMessage.success(res.message)
+        emit('load')
         dialogVisible.value = false
       })
       .finally(() => {
@@ -182,6 +183,7 @@ const editConfig = () => {
 defineExpose({
   show
 })
+const emit = defineEmits(['load'])
 
 </script>
 

--- a/ui/src/home/List.vue
+++ b/ui/src/home/List.vue
@@ -169,8 +169,7 @@ import Popconfirm from "../other/Popconfirm.vue";
 import PlayList from "../play/PlayList.vue";
 import Cover from "./Cover.vue";
 
-
-const weekList = ref([
+const defaultWeekList = [
   {
     i: 1,
     label: '星期日'
@@ -198,8 +197,9 @@ const weekList = ref([
   {
     i: 7,
     label: '星期六'
-  }]
-)
+  }
+]
+const weekList = ref(defaultWeekList)
 
 const pagerCount = ref(10)
 const refEdit = ref()
@@ -254,11 +254,10 @@ const getList = () => {
         showPlaylist.value = res.data.showPlaylist
         weekShow.value = res.data.weekShow
         scoreShow.value = res.data.scoreShow
-        if (!weekShow.value) {
-          weekList.value = [{
-            i: 1,
-            label: ''
-          }]
+        if (weekShow.value) {
+          weekList.value = defaultWeekList;
+        } else {
+          weekList.value = [{ i: 1, label: '' }];
         }
         api.get('api/ani')
             .then(res => {


### PR DESCRIPTION
1. 在修改配置后重新reload一下界面，在配置了星期展示等配置时可以获得更好的体验
2. 修复了一个重载界面的bug，当页面为不按星期展示时，weekList已经被置为了空，在配置了按照星期展示后，调用getList接口时，weekList没有被恢复。最新版的复现方法：在默认不按星期展示时进入界面->修改配置为按照星期展示->添加或删除rss，界面就会变成空白。