### PR TITLE
增加 Alist Refresh 功能

### DIFF
--- a/src/main/java/ani/rss/entity/Config.java
+++ b/src/main/java/ani/rss/entity/Config.java
@@ -617,4 +617,14 @@ public class Config implements Serializable {
      * github Token
      */
     private String githubToken;
+
+    /**
+     * 开启 Alist 列表刷新
+     */
+    private Boolean alistRefresh;
+
+    /**
+     * Alist 刷新延迟
+     */
+    private Long alistRefreshDelayed;
 }

--- a/src/main/java/ani/rss/util/ConfigUtil.java
+++ b/src/main/java/ani/rss/util/ConfigUtil.java
@@ -159,7 +159,9 @@ public class ConfigUtil {
                 .setProcrastinating(false)
                 .setProcrastinatingDay(14)
                 .setGithub("None")
-                .setGithubToken("");
+                .setGithubToken("")
+                .setAlistRefresh(false)
+                .setAlistRefreshDelayed(0L);
     }
 
     /**

--- a/src/main/java/ani/rss/util/TorrentUtil.java
+++ b/src/main/java/ani/rss/util/TorrentUtil.java
@@ -788,6 +788,7 @@ public class TorrentUtil {
             log.error(e.getMessage(), e);
         }
         AlistUtil.upload(torrentsInfo, ani);
+        AlistUtil.refresh(ani);
         String text = StrFormatter.format("{} 下载完成", name);
         if (tags.contains(TorrentsTags.BACK_RSS.getValue())) {
             text = StrFormatter.format("(备用RSS) {}", text);

--- a/ui/src/config/Download.vue
+++ b/ui/src/config/Download.vue
@@ -125,7 +125,7 @@
       <el-switch v-model:model-value="props.config.watchErrorTorrent"/>
     </el-form-item>
     <el-collapse>
-      <el-collapse-item title="qBittorrent设置">
+      <el-collapse-item title="qBittorrent 设置">
         <el-form-item label="下载速度限制">
           <el-input-number v-model:model-value="props.config['dlLimit']" :min="0">
             <template #suffix>
@@ -186,7 +186,7 @@
           </div>
         </el-form-item>
       </el-collapse-item>
-      <el-collapse-item title="Alist自动上传">
+      <el-collapse-item title="Alist 设置">
         <el-form-item label="AlistHost">
           <el-input v-model:model-value="props.config['alistHost']" placeholder="http://127.0.0.1:5244"/>
         </el-form-item>
@@ -202,17 +202,36 @@
         <el-form-item label="失败重试次数">
           <el-input-number v-model:model-value="props.config['alistRetry']" :max="100" :min="1"/>
         </el-form-item>
-        <el-form-item label="开关">
+        <el-form-item label="上传开关">
           <div style="width: 100%">
             <div>
               <el-switch v-model:model-value="props.config['alist']"/>
             </div>
             <div>
               <el-text class="mx-1" size="small">
-                自动将下载完成的文件上传至alist
+                自动将下载完成的文件上传至 alist
               </el-text>
             </div>
           </div>
+        </el-form-item>
+        <el-form-item label="刷新开关">
+          <div style="width: 100%">
+            <div>
+              <el-switch v-model:model-value="props.config['alistRefresh']"/>
+            </div>
+            <div>
+              <el-text class="mx-1" size="small">
+                刷新 alist 上传路径的文件列表
+              </el-text>
+            </div>
+          </div>
+        </el-form-item>
+        <el-form-item label="刷新延迟">
+          <el-input-number v-model="props.config['alistRefreshDelayed']" :min="0">
+            <template #suffix>
+              <span>秒</span>
+            </template>
+          </el-input-number>
         </el-form-item>
       </el-collapse-item>
     </el-collapse>


### PR DESCRIPTION
下载完成后（延迟）刷新 alist 目录，便于一些通过挂载 alist 搭建的 emby 及时扫库。此功能独立与 alist 上传（方便不通过 alist 上传的人），但是依赖 AlistToken、AlistHost、上传位置的设置项。

因此也调整了 webUI：

![image](https://github.com/user-attachments/assets/396c2360-6cd1-488e-855d-ffbe853823d2)

也有正常的日志输出，目前使用了一天，感觉没什么问题。