### PR TITLE
Alist 刷新优化

### DIFF
--- a/src/main/java/ani/rss/util/TorrentUtil.java
+++ b/src/main/java/ani/rss/util/TorrentUtil.java
@@ -793,7 +793,7 @@ public class TorrentUtil {
             log.error(e.getMessage(), e);
         }
         try {
-            AlistUtil.refresh(ani);
+            AlistUtil.refresh(torrentsInfo, ani);
         } catch (Exception e) {
             log.error(e.getMessage(), e);
         }


### PR DESCRIPTION
刷新目录更改为文件保存目录，比如：
原先：/Media/Bangumi/
现在：/Media/Bangumi//小市民系列 第二季/S02

原先的方法如果根目录的子文件夹数量不变，新文件无法刷新；直接刷新一个不存在的目录会 500, 所以现在的办法是先刷一遍根目录，再继续往下刷。

PS，upload 方法也修改了，没测试过。