### PR TITLE
2.0.35

### DIFF
--- a/UPDATE.md
+++ b/UPDATE.md
@@ -1,6 +1,10 @@
-- 增加通知 执行外部程序
-- 添加合集时可手动调整是否为剧场版
+## 改动
 
-close #470
+- 增加了一些代理测试网址
+- WebHook通知支持 `${imageBase64}` 合并于 #474
+
+## 贡献者
+
+@sosorin
 
 [从1.0升级至2.0的配置继承](https://github.com/wushuo894/ani-rss/discussions/427)

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>ani.rss</groupId>
     <artifactId>ani-rss</artifactId>
-    <version>2.0.34</version>
+    <version>2.0.35</version>
     <organization>
         <name>wushuo894</name>
     </organization>

--- a/ui/package.json
+++ b/ui/package.json
@@ -11,7 +11,7 @@
   "dependencies": {
     "@element-plus/icons-vue": "^2.3.1",
     "@vicons/fa": "^0.13.0",
-    "@vueuse/core": "^13.5.0",
+    "@vueuse/core": "^13.6.0",
     "artplayer": "^5.2.3",
     "artplayer-plugin-multiple-subtitles": "^1.1.0",
     "crypto-js": "^4.2.0",
@@ -21,7 +21,7 @@
     "vue": "^3.5.18"
   },
   "devDependencies": {
-    "@vitejs/plugin-vue": "^6.0.0",
+    "@vitejs/plugin-vue": "^6.0.1",
     "shiki": "^3.8.1",
     "vite": "^7.0.6"
   }


### PR DESCRIPTION
## 改动

- 增加了一些代理测试网址
- WebHook通知支持 `${imageBase64}` 合并于 #474

## 贡献者

@sosorin