### PR TITLE
feat: 优化分包

### DIFF
--- a/ui/package.json
+++ b/ui/package.json
@@ -23,6 +23,9 @@
   "devDependencies": {
     "@vitejs/plugin-vue": "^6.0.1",
     "shiki": "^3.8.1",
+    "terser": "^5.43.1",
+    "unplugin-auto-import": "^19.3.0",
+    "unplugin-vue-components": "^28.8.0",
     "vite": "^7.0.6"
   }
 }

--- a/ui/src/main.js
+++ b/ui/src/main.js
@@ -1,14 +1,11 @@
 import {createApp} from 'vue'
-import 'element-plus/dist/index.css'
 import Login from './Login.vue'
-import ElementPlus from 'element-plus'
 import * as ElementPlusIconsVue from '@element-plus/icons-vue'
-import 'element-plus/theme-chalk/dark/css-vars.css'
 import {zhCn} from "element-plus/es/locale/index";
 import './style.css'
 
 const app = createApp(Login)
-app.use(ElementPlus, {
+app.provide('$ELEMENT', {
     locale: zhCn,
 })
 // 引入图标

--- a/ui/vite.config.js
+++ b/ui/vite.config.js
@@ -1,8 +1,10 @@
 import {defineConfig} from 'vite'
 import vue from '@vitejs/plugin-vue'
 import path from 'path'
+import AutoImport from 'unplugin-auto-import/vite'
+import Components from 'unplugin-vue-components/vite'
+import { ElementPlusResolver } from 'unplugin-vue-components/resolvers'
 
-// https://vitejs.dev/config/
 export default defineConfig({
     base: './',
     server: {
@@ -14,10 +16,44 @@ export default defineConfig({
             }
         }
     },
-    plugins: [vue()],
+    plugins: [
+        vue(),
+        AutoImport({
+            imports: ['vue'],
+            resolvers: [ElementPlusResolver()]
+        }),
+        Components({
+            resolvers: [ElementPlusResolver({
+                importStyle: 'css',
+            })]
+        })
+    ],
     resolve: {
         alias: {
             '@': path.resolve(__dirname, './src/')
+        }
+    },
+    build: {
+        rollupOptions: {
+            output: {
+                manualChunks: {
+                    vue: ['vue', '@vueuse/core', '@vicons/fa'],
+                    utils: ['crypto-js', 'markdown-it', 'markdown-it-github-alerts'],
+                    'element-icon': ['@element-plus/icons-vue'],
+                    'artplayer': ['artplayer', 'artplayer-plugin-multiple-subtitles'],
+                    'shiki': ['shiki']
+                },
+                chunkFileNames: () => {
+                    return `assets/[name]-[hash].js`;
+                }
+            }
+        },
+        minify: 'terser',
+        terserOptions: {
+            compress: {
+                drop_console: true,
+                drop_debugger: true,
+            }
         }
     }
 })


### PR DESCRIPTION
优化首屏加载，内网可能无所谓，但是外网网速较慢情况下可能就比较有用

1. 按需引入 Element Plus
2. 添加 Terser 进行代码压缩
3. 配置手动分包策略

```
优化前: dist/assets/index-C-Ue-azI.js 1,783.74 kB
优化后: dist/assets/index-C63oUwgv.js 662.31 kB
```
体积减少了约 63%