### PR TITLE
设置新增 plex标题命名风格 开关

### DIFF
--- a/src/main/java/ani/rss/entity/Config.java
+++ b/src/main/java/ani/rss/entity/Config.java
@@ -620,4 +620,9 @@ public class Config implements Serializable {
      * 排序方式
      */
     private SortTypeEnum sortType;
+
+    /**
+     * 剧集标题是否支持plex命名方式
+     */
+    private Boolean plexTitleMode;
 }

--- a/src/main/java/ani/rss/enums/StringEnum.java
+++ b/src/main/java/ani/rss/enums/StringEnum.java
@@ -4,6 +4,7 @@ public class StringEnum {
     public static final String SEASON_REG = "[Ss](\\d+)[Ee](\\d+(\\.5)?)";
     public static final String YEAR_REG = " ?\\(((19|20)\\d{2})\\)";
     public static final String TMDB_ID_REG = " ?\\[tmdbid=(\\d+)]";
+    public static final String PLEX_TMDB_ID_REG = " ?\\{tmdb-(\\d+)}";
     public static final String MAGNET_REG = "^magnet\\:\\?xt=urn:btih\\:(\\w+)";
     public static final String SUBGROUP_REG_STR = "^\\{\\{(.+)}}:(.+)$";
 }

--- a/src/main/java/ani/rss/util/ConfigUtil.java
+++ b/src/main/java/ani/rss/util/ConfigUtil.java
@@ -210,7 +210,9 @@ public class ConfigUtil {
                 .setNotificationConfigList(new ArrayList<>())
                 .setApiKey(apiKey)
                 .setCopyMasterToStandby(false)
-                .setSortType(SortTypeEnum.SCORE);
+                .setSortType(SortTypeEnum.SCORE)
+                .setPlexTitleMode(false)
+        ;
     }
 
     /**

--- a/src/main/java/ani/rss/util/RenameUtil.java
+++ b/src/main/java/ani/rss/util/RenameUtil.java
@@ -288,8 +288,14 @@ public class RenameUtil {
         Boolean renameDelTmdbId = config.getRenameDelTmdbId();
 
         if (renameDelTmdbId) {
-            title = ReUtil.replaceAll(title, StringEnum.TMDB_ID_REG, "")
-                    .trim();
+            if (config.getPlexTitleMode()) {
+                title = ReUtil.replaceAll(title, StringEnum.PLEX_TMDB_ID_REG, "")
+                        .trim();
+            } else {
+                title = ReUtil.replaceAll(title, StringEnum.TMDB_ID_REG, "")
+                        .trim();
+            }
+
         }
 
         if (renameDelYear) {

--- a/src/main/java/ani/rss/util/TmdbUtil.java
+++ b/src/main/java/ani/rss/util/TmdbUtil.java
@@ -88,7 +88,11 @@ public class TmdbUtil {
         }
 
         if (config.getTmdbId()) {
-            themoviedbName = StrFormatter.format("{} [tmdbid={}]", themoviedbName, tmdb.getId());
+            if (config.getPlexTitleMode()) {
+                themoviedbName = StrFormatter.format("{} {tmdb-{}}", themoviedbName, tmdb.getId());
+            } else {
+                themoviedbName = StrFormatter.format("{} [tmdbid={}]", themoviedbName, tmdb.getId());
+            }
         }
 
         return themoviedbName;
@@ -154,7 +158,13 @@ public class TmdbUtil {
         Config config = ConfigUtil.CONFIG;
         String tmdbLanguage = config.getTmdbLanguage();
 
-        titleName = ReUtil.replaceAll(titleName, StringEnum.TMDB_ID_REG, "");
+        if (config.getPlexTitleMode()) {
+            titleName = ReUtil.replaceAll(titleName, StringEnum.PLEX_TMDB_ID_REG, "")
+                    .trim();
+        } else {
+            titleName = ReUtil.replaceAll(titleName, StringEnum.TMDB_ID_REG, "")
+                    .trim();
+        }
         titleName = ReUtil.replaceAll(titleName, StringEnum.YEAR_REG, "");
         titleName = titleName.trim();
         if (StrUtil.isBlank(titleName)) {

--- a/ui/src/config/Download.vue
+++ b/ui/src/config/Download.vue
@@ -120,6 +120,11 @@
         </el-alert>
       </div>
     </el-form-item>
+    <el-form-item label="plex标题命名风格">
+      <div>
+        <el-switch v-model:model-value="props.config['plexTitleMode']"/>
+      </div>
+    </el-form-item>
     <el-form-item label="自动删除">
       <div>
         <el-switch v-model:model-value="props.config.delete"/>


### PR DESCRIPTION
<img width="1245" height="775" alt="image" src="https://github.com/user-attachments/assets/b2b2a804-a719-4ba4-b511-8aa30b65eb50" />
<img width="734" height="634" alt="image" src="https://github.com/user-attachments/assets/06c08668-babe-4c28-878c-20e013719322" />


配置文件中新增 plexTitleMode 剧集标题是否支持plex命名方式 

开启后默认替换项目中的 [tmdbid={}] 为 {tmdb-{}}

方便plex用户