### PR TITLE
添加了"仅启用主RSS摸鱼检测"开关

### DIFF
--- a/src/main/java/ani/rss/entity/Config.java
+++ b/src/main/java/ani/rss/entity/Config.java
@@ -215,6 +215,11 @@ public class Config implements Serializable {
     private Boolean debug;
 
     /**
+     * 仅启用主rss摸鱼检测
+     */
+    private Boolean procrastinatingMasterOnly;
+
+    /**
      * 代理是否开启
      */
     private Boolean proxy;

--- a/src/main/java/ani/rss/util/ConfigUtil.java
+++ b/src/main/java/ani/rss/util/ConfigUtil.java
@@ -139,6 +139,7 @@ public class ConfigUtil {
                 .setCoexist(false)
                 .setLogsMax(2048)
                 .setDebug(false)
+                .setProcrastinatingMasterOnly(true)
                 .setProxy(false)
                 .setProxyHost("")
                 .setProxyPort(8080)

--- a/src/main/java/ani/rss/util/ItemsUtil.java
+++ b/src/main/java/ani/rss/util/ItemsUtil.java
@@ -401,8 +401,13 @@ public class ItemsUtil {
             return;
         }
 
+        if (Boolean.TRUE.equals(config.getProcrastinatingMasterOnly())) {
+            items = items.stream()
+                    .filter(Item::getMaster)
+                    .toList();
+        }
+
         items.stream()
-                .filter(Item::getMaster)
                 .map(Item::getPubDate)
                 .filter(Objects::nonNull)
                 .mapToLong(Date::getTime)

--- a/ui/src/config/basic/Other.vue
+++ b/ui/src/config/basic/Other.vue
@@ -47,6 +47,9 @@
         </div>
       </div>
     </el-form-item>
+    <el-form-item label="仅启用主RSS摸鱼检测">
+      <el-switch v-model:model-value="props.config.procrastinatingMasterOnly"/>
+    </el-form-item>
     <el-form-item label="DEBUG">
       <el-switch v-model:model-value="props.config.debug"/>
     </el-form-item>


### PR DESCRIPTION
# 功能说明

- 默认为 **开启**，保持原有逻辑不变。
- 如果 **关闭**，系统会同时检测 **主 RSS** 和 **备用 RSS**：
  - 备用 RSS 有更新，就不会提示“摸鱼”。

---

## 设置界面

- 功能默认开启，逻辑保持不变：

![默认状态](https://github.com/user-attachments/assets/b045e337-4691-4f1b-9358-9f481bdd2252)

---

## 使用前

- 当主 RSS 字幕组弃坑后，添加了备用 RSS。
- 备用 RSS 在正常更新，但仍会提示“摸鱼”。

![使用前示例](https://github.com/user-attachments/assets/dd788771-d4cb-4367-9356-ec55ed2e2cca)

---

## 使用后

- 当启用该功能后，主 RSS 和备用 RSS 都长期未更新，才会提示“摸鱼”。

![使用后示例](https://github.com/user-attachments/assets/1ae7a00f-3ad5-47f7-9b76-8a4fd608b90b)