### PR TITLE
优化emby判断播放完成的逻辑

### DIFF
--- a/src/main/java/ani/rss/action/WebHookAction.java
+++ b/src/main/java/ani/rss/action/WebHookAction.java
@@ -81,7 +81,26 @@ public class WebHookAction implements BaseAction {
 
         response.sendOk();
 
-        int type = "item.markunplayed".equalsIgnoreCase(body.get("Event").getAsString()) ? 0 : 2;
+        String event = body.get("Event").getAsString();
+        int type;
+
+        if ("item.markunplayed".equalsIgnoreCase(event)) {
+            type = 0; // 标记未看
+
+        } else if ("playback.stop".equalsIgnoreCase(event)) {
+            boolean playedToCompletion = body.has("PlaybackInfo")
+                    && body.getAsJsonObject("PlaybackInfo").has("PlayedToCompletion")
+                    && body.getAsJsonObject("PlaybackInfo").get("PlayedToCompletion").getAsBoolean();
+
+            if (playedToCompletion) {
+                type = 2;
+            } else {
+                return;
+            }
+
+        } else {
+            return;
+        }
 
         EXECUTOR.execute(() -> {
             log.info("{} 标记为 [{}]", fileName, List.of("未看过", "想看", "看过").get(type));


### PR DESCRIPTION
目前的逻辑是
1 用户手动更新播放状态
2 接收到不为item.markunplayed类型的通知就视为播放完成
但实际上情况2中 当且仅当接收到playback.stop事件且其中的参数PlaybackInfo.PlayedToCompletion为true的这一种情况才应当判定播放完成