### PR TITLE
fix: 修复 qBittorrent 登录验证以支持 HTTP 204 响应

### DIFF
--- a/ani-rss-core/src/main/java/ani/rss/download/qBittorrent.java
+++ b/ani-rss-core/src/main/java/ani/rss/download/qBittorrent.java
@@ -103,8 +103,6 @@ public class qBittorrent implements BaseDownload {
                     .disableCookie()
                     .thenFunction(res -> {
                         HttpReq.assertStatus(res);
-                        String body = res.body();
-                        Assert.isTrue("Ok.".equals(body), "body: {}", body);
                         return true;
                     });
         } catch (Exception e) {


### PR DESCRIPTION


<img width="1147" height="517" alt="image" src="https://github.com/user-attachments/assets/6c8d1679-c75a-443d-b345-f74ca6bd60e5" />
<img width="2807" height="1167" alt="image" src="https://github.com/user-attachments/assets/15e70a72-dc0f-464f-ade4-10ce64521fe3" />

这个版本的 qBittorrent 的 /api/v2/auth/login 接口在成功登录时返回 HTTP 204 No Content 和空响应体，而不是之前硬编码期望的 "Ok." 字符串，导致test失败，但是能够正常下载，所以移除了响应体的内容检查，只依赖 HTTP 状态码验证。