### PR TITLE
fix(api): fix API endpoints and request handling

### DIFF
--- a/ani-rss-application/src/main/java/ani/rss/controller/AboutController.java
+++ b/ani-rss-application/src/main/java/ani/rss/controller/AboutController.java
@@ -15,7 +15,7 @@ import io.swagger.v3.oas.annotations.Operation;
 import jakarta.servlet.http.HttpServletRequest;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RestController;
 
 import java.io.File;
@@ -35,7 +35,7 @@ public class AboutController {
     @Auth
     @Operation(summary = "停止服务")
     @PostMapping("/stop")
-    public Result<Void> stop(@RequestParam("status") Integer status) {
+    public Result<Void> stop(@RequestBody Integer status) {
         String s = List.of("重启", "关闭").get(status);
         log.info("正在{}", s);
         ThreadUtil.execute(() -> {

--- a/ani-rss-ui/src/home/Cover.vue
+++ b/ani-rss-ui/src/home/Cover.vue
@@ -24,7 +24,7 @@
                     :action="`api/upload?s=${authorization}`"
                     :before-upload="beforeAvatarUpload"
                     :on-success="res => {
-                      ani['cover'] = res.data.data
+                      ani['cover'] = res.data
                       time = new Date().getTime()
                     }"
                     :show-file-list="false"
@@ -69,7 +69,7 @@ let reLoad = () => {
   http.refreshCover(ani.value)
       .then(res => {
         time.value = new Date().getTime()
-        ani.value.refreshCover = res.data
+        ani.value.cover = res.data
       })
       .finally(res => {
         reLoadIng.value = false

--- a/ani-rss-ui/src/js/http.js
+++ b/ani-rss-ui/src/js/http.js
@@ -256,7 +256,7 @@ export let trackersUpdate = (config) => api.post('api/trackersUpdate', config)
  * @param config 设置
  * @returns {Promise<unknown>}
  */
-export let getEmbyViews = (config) => api.post('api/getEmbyViews', config)
+export let getEmbyViews = (config) => api.post('api/emby/getEmbyViews', config)
 
 /**
  * 清理缓存


### PR DESCRIPTION
1. 前端url缺少emby 头
前端请求没有，后端有
<img width="1109" height="331" alt="image" src="https://github.com/user-attachments/assets/9bfb4380-3c79-4aa5-8bba-1006db562eff" />
2. stop 接口前端传参数在请求体，后端在url参数
<img width="2151" height="283" alt="image" src="https://github.com/user-attachments/assets/347cdcfb-dddb-4aa4-a137-f4c5c8d3fbfe" />
3.  这个不太确定：刷新页面后，应该是把返回值里的图片赋值给cover吧，你给了refreshCover，但没见其余地方用到