### PR TITLE
feat: 添加新的路径保存方式支持 Bangumi ID，下载路径模版支持 ${bgmId}

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,7 +1,11 @@
 .idea
 target
 logs
+node_modules
 /config
 *.log
 ani-rss-update.exe
 build_info
+*.iml
+.DS_Store
+Thumbs.db

--- a/ani-rss-application/src/main/java/ani/rss/entity/Config.java
+++ b/ani-rss-application/src/main/java/ani/rss/entity/Config.java
@@ -731,4 +731,13 @@ public class Config implements Serializable {
      */
     @Schema(description = "构建信息")
     private String buildInfo;
+
+    /**
+     * 路径保存方式
+     * 例如:
+     * - LegacyLetterTitleSeason: 旧版 按拼音首字母/标题/Season 结构
+     * - BangumiSubjectId: 按 Bangumi subject 数字 ID 作为目录
+     */
+    @Schema(description = "路径保存方式")
+    private String pathSaveMode;
 }

--- a/ani-rss-application/src/main/java/ani/rss/service/DownloadService.java
+++ b/ani-rss-application/src/main/java/ani/rss/service/DownloadService.java
@@ -523,9 +523,13 @@ public class DownloadService {
 
         String downloadPathTemplate = config.getDownloadPathTemplate();
         String ovaDownloadPathTemplate = config.getOvaDownloadPathTemplate();
-        if (ova && StrUtil.isNotBlank(ovaDownloadPathTemplate)) {
-            // 剧场版位置
-            downloadPathTemplate = ovaDownloadPathTemplate;
+        String pathSaveMode = config.getPathSaveMode();
+        // 当使用 Bangumi ID 路径模式时，不再单独区分剧场版下载路径，全部使用统一模版
+        if (!"BangumiSubjectId".equals(pathSaveMode)) {
+            if (ova && StrUtil.isNotBlank(ovaDownloadPathTemplate)) {
+                // 剧场版位置
+                downloadPathTemplate = ovaDownloadPathTemplate;
+            }
         }
 
         if (customDownloadPath && StrUtil.isNotBlank(aniDownloadPath)) {
@@ -612,6 +616,14 @@ public class DownloadService {
                 .orElse("");
 
         downloadPathTemplate = downloadPathTemplate.replace("${tmdbid}", tmdbId);
+
+        // 解析 bangumi subject 的数字 ID，例如 https://bangumi.tv/subject/123456
+        String bgmId = Opt.ofNullable(ani.getBgmUrl())
+                .filter(StrUtil::isNotBlank)
+                .map(url -> ReUtil.get("subject/(\\d+)", url, 1))
+                .orElse("");
+
+        downloadPathTemplate = downloadPathTemplate.replace("${bgmId}", bgmId);
 
         if (downloadPathTemplate.contains("${jpTitle}")) {
             String jpTitle = RenameUtil.getJpTitle(ani);

--- a/ani-rss-application/src/main/java/ani/rss/util/other/ConfigUtil.java
+++ b/ani-rss-application/src/main/java/ani/rss/util/other/ConfigUtil.java
@@ -227,7 +227,8 @@ public class ConfigUtil {
                 .setScrape(false)
                 .setReplace(false)
                 .setMaxFileNameLength(0)
-                .setLimitLoginAttempts(true);
+                .setLimitLoginAttempts(true)
+                .setPathSaveMode("LegacyLetterTitleSeason");
     }
 
     /**

--- a/ani-rss-ui/src/config/Download.vue
+++ b/ani-rss-ui/src/config/Download.vue
@@ -4,6 +4,28 @@
            @submit="(event)=>{
                     event.preventDefault()
                    }">
+    <el-form-item label="路径保存方式">
+      <div class="download-path-mode-container">
+        <el-select v-model:model-value="props.config.pathSaveMode">
+          <el-option
+              v-for="mode in pathSaveModeOptions"
+              :key="mode.key"
+              :label="mode.label"
+              :value="mode.key"
+          />
+        </el-select>
+        <div class="download-path-mode-description">
+          <el-text class="mx-1" size="small">
+            {{ currentPathSaveModeMeta.description }}
+          </el-text>
+        </div>
+        <div class="download-path-mode-recommend">
+          <el-text class="mx-1" size="small">
+            推荐模版：{{ currentPathSaveModeMeta.recommendedTemplates?.downloadPathTemplate ?? '' }}
+          </el-text>
+        </div>
+      </div>
+    </el-form-item>
     <el-form-item label="下载工具">
       <el-select v-model:model-value="props.config.downloadToolType">
         <el-option v-for="item in downloadSelect"
@@ -106,7 +128,9 @@
         </el-alert>
       </div>
     </el-form-item>
-    <el-form-item label="剧场版保存位置">
+    <el-form-item
+        v-if="props.config.pathSaveMode !== PATH_SAVE_MODES.BANGUMI_SUBJECT_ID"
+        label="剧场版保存位置">
       <div class="download-path-container">
         <el-input v-model:model-value="props.config['ovaDownloadPathTemplate']"/>
         <el-alert
@@ -192,13 +216,14 @@
 </template>
 
 <script setup>
-import {ref} from "vue";
+import {ref, computed} from "vue";
 import {ElMessage, ElText} from "element-plus";
 import {Key, User} from "@element-plus/icons-vue";
 import QBittorrent from "@/config/download/qBittorrent.vue";
 import PrioKeys from "@/config/PrioKeys.vue";
 import CustomTags from "@/config/CustomTags.vue";
 import * as http from "@/js/http.js";
+import {PATH_SAVE_MODES, PATH_SAVE_MODE_META} from "@/js/pathMode.js";
 
 const downloadSelect = ref([
   'qBittorrent',
@@ -250,6 +275,13 @@ let testPathTemplate = (path) => {
   return new RegExp('\\$\{[A-z]+\}').test(path);
 }
 
+const pathSaveModeOptions = computed(() => Object.values(PATH_SAVE_MODE_META));
+
+const currentPathSaveModeMeta = computed(() => {
+  const mode = props.config.pathSaveMode || PATH_SAVE_MODES.LEGACY_LETTER_TITLE_SEASON
+  return PATH_SAVE_MODE_META[mode] || PATH_SAVE_MODE_META[PATH_SAVE_MODES.LEGACY_LETTER_TITLE_SEASON]
+})
+
 let activeName = ref([])
 
 let props = defineProps(['config'])
@@ -284,5 +316,27 @@ let props = defineProps(['config'])
 
 .download-priority-container {
   width: 100%;
+}
+
+.download-path-mode-container {
+  width: 100%;
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+
+.download-path-mode-description {
+  max-width: 640px;
+}
+
+.download-path-mode-recommend {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 8px;
+}
+
+.download-path-mode-recommend-input {
+  max-width: 480px;
 }
 </style>

--- a/ani-rss-ui/src/js/config.js
+++ b/ani-rss-ui/src/js/config.js
@@ -126,5 +126,9 @@ export let configData = {
     "priorityKeywords": [],
     "procrastinatingMasterOnly": true,
     "limitLoginAttempts": true,
-    "buildInfo": ''
+    "buildInfo": '',
+    // 路径保存方式
+    // LegacyLetterTitleSeason: 旧版 按拼音首字母/标题/Season
+    // BangumiSubjectId: 使用 Bangumi subject 数字 ID 作为目录名
+    "pathSaveMode": "LegacyLetterTitleSeason"
 }

--- a/ani-rss-ui/src/js/pathMode.js
+++ b/ani-rss-ui/src/js/pathMode.js
@@ -1,0 +1,43 @@
+export const PATH_SAVE_MODES = {
+  LEGACY_LETTER_TITLE_SEASON: 'LegacyLetterTitleSeason',
+  BANGUMI_SUBJECT_ID: 'BangumiSubjectId',
+}
+
+export const PATH_SAVE_MODE_META = {
+  [PATH_SAVE_MODES.LEGACY_LETTER_TITLE_SEASON]: {
+    label: '拼音首字母 / 标题 / Season',
+    key: PATH_SAVE_MODES.LEGACY_LETTER_TITLE_SEASON,
+    recommendedTemplates: {
+      downloadPathTemplate: '/Users/wushuo/Movies/番剧/${letter}/${title}/Season ${season}',
+      ovaDownloadPathTemplate: '/Users/wushuo/Movies/剧场版/${letter}/${title}',
+    },
+    description: '按番剧标题拼音首字母分组，再按标题和季数建立目录，是 ani-rss 默认路径结构，适合本地媒体库按标题浏览。',
+    dataSources: [],
+  },
+  [PATH_SAVE_MODES.BANGUMI_SUBJECT_ID]: {
+    label: 'Bangumi subject ID 目录',
+    key: PATH_SAVE_MODES.BANGUMI_SUBJECT_ID,
+    recommendedTemplates: {
+      downloadPathTemplate: '/your/base/path/${bgmId}',
+      ovaDownloadPathTemplate: '/your/base/path/movie/${bgmId}',
+    },
+    description: '使用 Bangumi 条目 ID（例如 https://bangumi.tv/subject/123456 中的 123456）作为目录名，方便与追番工具和外部数据库做一一对应。此模式下不会区分剧场版和TV版。',
+    dataSources: [
+      {
+        name: 'bangumi-data',
+        url: 'https://github.com/bangumi-data/bangumi-data',
+        description: '以 JSON 维护的番剧与播放站点映射表，可用于自定义媒体路径或与 OpenList 等工具同步本地状态。',
+      },
+      {
+        name: 'Bangumi API',
+        url: 'https://github.com/bangumi/api',
+        description: 'bgm.tv 官方 API 规格，可实时获取番剧的标准集数、类型（SP / OVA 等）和放送时间，用于精确命名和分类。',
+      },
+      {
+        name: 'Anime-Offline-Database',
+        url: 'https://github.com/manami-project/anime-offline-database',
+        description: '跨 MyAnimeList、AniDB、Kitsu 等多个社区的 ID 离线映射表，可帮助在不同站点 ID 之间进行转换。',
+      },
+    ],
+  },
+}


### PR DESCRIPTION
- 新增配置 pathSaveMode：可选「旧版拼音/标题/Season」或「Bangumi subject ID 目录」
- 路径模版支持占位符 ${bgmId}（从 bgmUrl 解析）
- 选 Bangumi ID 模式时，TV 与剧场版共用同一路径，并隐藏剧场版保存位置输入框
- 新增 pathMode.js 维护路径模式与推荐模版