### PR TITLE
feat: 添加 MCP 支持

### DIFF
--- a/ani-rss-application/pom.xml
+++ b/ani-rss-application/pom.xml
@@ -150,6 +150,10 @@
             <artifactId>hutool-http</artifactId>
             <version>${hutool.version}</version>
         </dependency>
+        <dependency>
+            <groupId>org.springframework.ai</groupId>
+            <artifactId>spring-ai-starter-mcp-server-webmvc</artifactId>
+        </dependency>
     </dependencies>
 
     <build>

--- a/ani-rss-application/src/main/java/ani/rss/config/WebMvcConfig.java
+++ b/ani-rss-application/src/main/java/ani/rss/config/WebMvcConfig.java
@@ -4,6 +4,7 @@ import ani.rss.commons.GsonStatic;
 import org.jspecify.annotations.NonNull;
 import org.jspecify.annotations.Nullable;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.http.MediaType;
 import org.springframework.http.converter.HttpMessageConverters;
 import org.springframework.http.converter.json.GsonHttpMessageConverter;
 import org.springframework.web.bind.annotation.RestController;
@@ -12,6 +13,7 @@ import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
 import org.springframework.web.util.pattern.PathPatternParser;
 
 import java.io.Writer;
+import java.lang.reflect.ParameterizedType;
 import java.lang.reflect.Type;
 import java.nio.charset.StandardCharsets;
 
@@ -33,6 +35,29 @@ public class WebMvcConfig implements WebMvcConfigurer {
         builder.configureMessageConvertersList(converters -> {
             GsonHttpMessageConverter converter = new GsonHttpMessageConverter() {
                 @Override
+                public boolean canRead(@NonNull Class<?> clazz, @Nullable MediaType mediaType) {
+                    return clazz != String.class && !isMcpClass(clazz) && super.canRead(clazz, mediaType);
+                }
+
+                @Override
+                public boolean canRead(@Nullable Type type, @Nullable Class<?> contextClass, @Nullable MediaType mediaType) {
+                    return type != String.class
+                            && !isMcpType(type)
+                            && !isMcpClass(contextClass)
+                            && super.canRead(type, contextClass, mediaType);
+                }
+
+                @Override
+                public boolean canWrite(@NonNull Class<?> clazz, @Nullable MediaType mediaType) {
+                    return !isMcpClass(clazz) && super.canWrite(clazz, mediaType);
+                }
+
+                @Override
+                public boolean canWrite(@Nullable Type type, @Nullable Class<?> clazz, @Nullable MediaType mediaType) {
+                    return !isMcpType(type) && !isMcpClass(clazz) && super.canWrite(type, clazz, mediaType);
+                }
+
+                @Override
                 protected void writeInternal(@NonNull Object object, @Nullable Type type, @NonNull Writer writer) throws Exception {
                     if (object instanceof byte[]) {
                         try (writer) {
@@ -42,6 +67,27 @@ public class WebMvcConfig implements WebMvcConfigurer {
                         return;
                     }
                     super.writeInternal(object, type, writer);
+                }
+
+                private boolean isMcpType(@Nullable Type type) {
+                    if (type instanceof Class<?> clazz) {
+                        return isMcpClass(clazz);
+                    }
+                    if (type instanceof ParameterizedType parameterizedType) {
+                        if (isMcpType(parameterizedType.getRawType())) {
+                            return true;
+                        }
+                        for (Type actualTypeArgument : parameterizedType.getActualTypeArguments()) {
+                            if (isMcpType(actualTypeArgument)) {
+                                return true;
+                            }
+                        }
+                    }
+                    return false;
+                }
+
+                private boolean isMcpClass(@Nullable Class<?> clazz) {
+                    return clazz != null && clazz.getName().startsWith("io.modelcontextprotocol.");
                 }
             };
             converter.setGson(GsonStatic.GSON);

--- a/ani-rss-application/src/main/java/ani/rss/mcp/AniMcpTools.java
+++ b/ani-rss-application/src/main/java/ani/rss/mcp/AniMcpTools.java
@@ -1,0 +1,290 @@
+package ani.rss.mcp;
+
+import ani.rss.commons.ExceptionUtils;
+import ani.rss.commons.GroupRegexUtils;
+import ani.rss.dto.RssToAniDTO;
+import ani.rss.entity.*;
+import ani.rss.exception.ResultException;
+import ani.rss.service.AniBTService;
+import ani.rss.service.AnimeGardenService;
+import ani.rss.service.DownloadService;
+import ani.rss.service.MikanService;
+import ani.rss.util.other.AniUtil;
+import ani.rss.util.other.ConfigUtil;
+import ani.rss.util.other.ItemsUtil;
+import ani.rss.util.other.TorrentUtil;
+import cn.hutool.core.thread.ThreadUtil;
+import jakarta.annotation.Resource;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.ai.mcp.annotation.McpTool;
+import org.springframework.ai.mcp.annotation.McpToolParam;
+import org.springframework.stereotype.Component;
+
+import java.util.List;
+import java.util.Optional;
+
+@Slf4j
+@Component
+public class AniMcpTools {
+
+    @Resource
+    private MikanService mikanService;
+
+    @Resource
+    private AniBTService aniBTService;
+
+    @Resource
+    private AnimeGardenService animeGardenService;
+
+    @Resource
+    private DownloadService downloadService;
+
+    @McpTool(
+            name = "list_subscriptions",
+            description = "列出现有 ANI-RSS 订阅，可按启用状态过滤。",
+            annotations = @McpTool.McpAnnotations(
+                    title = "订阅列表",
+                    readOnlyHint = true,
+                    destructiveHint = false,
+                    idempotentHint = true,
+                    openWorldHint = false
+            )
+    )
+    public List<Ani> listSubscriptions(
+            @McpToolParam(description = "可选的启用状态过滤：true 只返回启用订阅，false 只返回禁用订阅，不传则返回全部", required = false)
+            Boolean enabled
+    ) {
+        return AniUtil.ANI_LIST.stream()
+                .filter(ani -> enabled == null || enabled.equals(ani.getEnable()))
+                .toList();
+    }
+
+    @McpTool(
+            name = "search_mikan",
+            description = "按关键词搜索 Mikan 番剧，可传入季度条件。",
+            annotations = @McpTool.McpAnnotations(
+                    title = "搜索 Mikan",
+                    readOnlyHint = true,
+                    destructiveHint = false,
+                    idempotentHint = true
+            )
+    )
+    public Mikan searchMikan(
+            @McpToolParam(description = "搜索关键词", required = true)
+            String text,
+            @McpToolParam(description = "可选季度过滤，例如年份和季度", required = false)
+            Mikan.Season season
+    ) {
+        return mikanService.list(text, season);
+    }
+
+    @McpTool(
+            name = "search_anibt",
+            description = "搜索 AniBT 番剧，可按季度或 BGM 地址过滤。",
+            annotations = @McpTool.McpAnnotations(
+                    title = "搜索 AniBT",
+                    readOnlyHint = true,
+                    destructiveHint = false,
+                    idempotentHint = true
+            )
+    )
+    public AniBT searchAniBT(
+            @McpToolParam(description = "季度标识，例如 2026-04；不传则使用 AniBT 默认季度", required = false)
+            String season,
+            @McpToolParam(description = "可选 BGM 番剧地址，用于定位单个番剧", required = false)
+            String bgmUrl
+    ) {
+        return aniBTService.list(season, bgmUrl);
+    }
+
+    @McpTool(
+            name = "search_anime_garden",
+            description = "搜索 AnimeGarden 番剧列表，可传入 BGM 地址定位单个番剧。",
+            annotations = @McpTool.McpAnnotations(
+                    title = "搜索 AnimeGarden",
+                    readOnlyHint = true,
+                    destructiveHint = false,
+                    idempotentHint = true
+            )
+    )
+    public List<AnimeGarden.Week> searchAnimeGarden(
+            @McpToolParam(description = "可选 BGM 番剧地址，用于定位单个番剧；不传则返回 AnimeGarden 当前列表", required = false)
+            String bgmUrl
+    ) {
+        return animeGardenService.list(bgmUrl);
+    }
+
+    @McpTool(
+            name = "get_mikan_groups",
+            description = "根据 Mikan 番剧页面 URL 获取字幕组 RSS。",
+            annotations = @McpTool.McpAnnotations(
+                    title = "获取 Mikan 字幕组",
+                    readOnlyHint = true,
+                    destructiveHint = false,
+                    idempotentHint = true
+            )
+    )
+    public List<Mikan.Group> getMikanGroups(
+            @McpToolParam(description = "蜜柑（Mikan）番剧页面 URL", required = true)
+            String url
+    ) {
+        List<Mikan.Group> groups = mikanService.getGroups(url);
+        for (Mikan.Group group : groups) {
+            List<Mikan.Item> items = group.getItems();
+            GroupRegex groupRegx = GroupRegexUtils.toGroupRegx(items, Mikan.Item::getTitle);
+            group.setGroupRegex(groupRegx);
+        }
+        return groups;
+    }
+
+    @McpTool(
+            name = "get_anibt_groups",
+            description = "根据 AniBT BGM ID 获取字幕组 RSS。",
+            annotations = @McpTool.McpAnnotations(
+                    title = "获取 AniBT 字幕组",
+                    readOnlyHint = true,
+                    destructiveHint = false,
+                    idempotentHint = true
+            )
+    )
+    public List<AniBT.Group> getAniBTGroups(
+            @McpToolParam(description = "BGM 番剧 ID", required = true)
+            String bgmId
+    ) {
+        List<AniBT.Group> groups = aniBTService.getGroups(bgmId);
+        for (AniBT.Group group : groups) {
+            List<AniBT.Item> items = group.getItems();
+            GroupRegex groupRegx = GroupRegexUtils.toGroupRegx(items, AniBT.Item::getTitle);
+
+            group.setBgmId(bgmId)
+                    .setGroupRegex(groupRegx);
+        }
+        return groups;
+    }
+
+    @McpTool(
+            name = "get_anime_garden_groups",
+            description = "根据 AnimeGarden BGM ID 获取字幕组 RSS。",
+            annotations = @McpTool.McpAnnotations(
+                    title = "获取 AnimeGarden 字幕组",
+                    readOnlyHint = true,
+                    destructiveHint = false,
+                    idempotentHint = true
+            )
+    )
+    public List<AnimeGarden.Group> getAnimeGardenGroups(
+            @McpToolParam(description = "BGM 番剧 ID")
+            String bgmId
+    ) {
+        return animeGardenService.group(bgmId);
+    }
+
+    @McpTool(
+            name = "preview_subscription_items",
+            description = "预览某个 RSS 订阅最终会命中的原始剧集条目，不添加订阅。",
+            annotations = @McpTool.McpAnnotations(
+                    title = "预览订阅条目",
+                    readOnlyHint = true,
+                    destructiveHint = false,
+                    idempotentHint = true
+            )
+    )
+    public SubscriptionItemsPreview previewSubscriptionItems(
+            @McpToolParam(description = "订阅预览请求，包含 RSS 地址 url、类型 type、字幕组 subgroup、BGM 地址 bgmUrl 等字段", required = true)
+            RssToAniDTO request
+    ) {
+        try {
+            Ani ani = AniUtil.getAni(request);
+            return new SubscriptionItemsPreview(ani, ItemsUtil.getItems(ani));
+        } catch (Exception e) {
+            throw mcpException("RSS解析失败", e);
+        }
+    }
+
+    @McpTool(
+            name = "create_subscription",
+            description = "根据 RSS 请求创建一个 ANI-RSS 订阅。需要预览命中条目时请先调用 preview_subscription_items。",
+            annotations = @McpTool.McpAnnotations(
+                    title = "创建订阅",
+                    destructiveHint = false
+            )
+    )
+    public Ani createSubscription(
+            @McpToolParam(description = "订阅创建请求，包含 RSS 地址 url、类型 type、字幕组 subgroup、BGM 地址 bgmUrl 等字段", required = true)
+            RssToAniDTO request,
+            @McpToolParam(description = "创建后是否启用订阅", required = false)
+            Boolean enable
+    ) {
+        try {
+            Ani ani = AniUtil.getAni(request);
+            if (enable != null) {
+                ani.setEnable(enable);
+            }
+            return addAni(ani);
+        } catch (Exception e) {
+            throw mcpException("创建订阅失败", e);
+        }
+    }
+
+    private Ani addAni(Ani ani) {
+        ani.setTitle(ani.getTitle().trim())
+                .setUrl(ani.getUrl().trim());
+        AniUtil.verify(ani);
+
+        Optional<Ani> first = AniUtil.ANI_LIST.stream()
+                .filter(it -> it.getId().equals(ani.getId()))
+                .findFirst();
+        if (first.isPresent()) {
+            throw new IllegalArgumentException("此订阅已存在");
+        }
+
+        first = AniUtil.ANI_LIST.stream()
+                .filter(it -> it.getTitle().equals(ani.getTitle()) && it.getSeason().equals(ani.getSeason()))
+                .findFirst();
+        if (first.isPresent()) {
+            Config config = ConfigUtil.CONFIG;
+            if (config.getReplace()) {
+                AniUtil.ANI_LIST.remove(first.get());
+                log.info("自动替换 {} 第{}季", ani.getTitle(), ani.getSeason());
+            } else {
+                throw new IllegalArgumentException("订阅标题重复");
+            }
+        }
+
+        AniUtil.ANI_LIST.add(ani);
+        AniUtil.sync();
+        if (ani.getEnable()) {
+            ThreadUtil.execute(() -> {
+                if (TorrentUtil.login()) {
+                    downloadService.downloadAni(ani);
+                }
+            });
+        } else {
+            ThreadUtil.execute(() -> {
+                try {
+                    List<Item> items = ItemsUtil.getItems(ani);
+                    int currentEpisodeNumber = ItemsUtil.currentEpisodeNumber(ani, items);
+                    ani.setCurrentEpisodeNumber(currentEpisodeNumber);
+                } catch (Exception e) {
+                    log.error(ExceptionUtils.getMessage(e), e);
+                }
+            });
+        }
+        log.info("添加订阅 {} {} {}", ani.getTitle(), ani.getUrl(), ani.getId());
+        return ani;
+    }
+
+    private RuntimeException mcpException(String action, Exception e) {
+        String message = e instanceof ResultException resultException
+                ? resultException.getResult().getMessage()
+                : ExceptionUtils.getMessage(e);
+        log.error("{}: {}", action, message, e);
+        return new IllegalArgumentException(action + ": " + message, e);
+    }
+
+    public record SubscriptionItemsPreview(
+            Ani subscription,
+            List<Item> items
+    ) {
+    }
+}

--- a/ani-rss-application/src/main/java/ani/rss/mcp/McpEndpointConfig.java
+++ b/ani-rss-application/src/main/java/ani/rss/mcp/McpEndpointConfig.java
@@ -1,0 +1,78 @@
+package ani.rss.mcp;
+
+import ani.rss.annotation.Auth;
+import ani.rss.auth.enums.AuthType;
+import ani.rss.exception.ResultException;
+import io.modelcontextprotocol.json.jackson3.JacksonMcpJsonMapper;
+import io.modelcontextprotocol.server.transport.ServerTransportSecurityException;
+import io.modelcontextprotocol.spec.McpSchema;
+import org.springframework.ai.mcp.server.common.autoconfigure.McpServerAutoConfiguration;
+import org.springframework.ai.mcp.server.common.autoconfigure.McpServerStdioDisabledCondition;
+import org.springframework.ai.mcp.server.common.autoconfigure.properties.McpServerStreamableHttpProperties;
+import org.springframework.ai.mcp.server.webmvc.transport.WebMvcStreamableServerTransportProvider;
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnClass;
+import org.springframework.boot.context.properties.EnableConfigurationProperties;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Conditional;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
+import tools.jackson.databind.json.JsonMapper;
+
+import java.util.List;
+import java.util.Map;
+
+@Configuration
+@ConditionalOnClass(McpSchema.class)
+@EnableConfigurationProperties(McpServerStreamableHttpProperties.class)
+@Conditional({
+        McpServerStdioDisabledCondition.class,
+        McpServerAutoConfiguration.EnabledStreamableServerCondition.class
+})
+public class McpEndpointConfig implements WebMvcConfigurer {
+
+    @Bean
+    public McpTransportAuth mcpTransportAuth() {
+        return new McpTransportAuth();
+    }
+
+    @Bean
+    public WebMvcStreamableServerTransportProvider webMvcStreamableServerTransportProvider(
+            @Qualifier("mcpServerJsonMapper") JsonMapper jsonMapper,
+            McpServerStreamableHttpProperties serverProperties,
+            McpTransportAuth mcpTransportAuth
+    ) {
+        return WebMvcStreamableServerTransportProvider.builder()
+                .jsonMapper(new JacksonMcpJsonMapper(jsonMapper))
+                .mcpEndpoint(serverProperties.getMcpEndpoint())
+                .keepAliveInterval(serverProperties.getKeepAliveInterval())
+                .disallowDelete(serverProperties.isDisallowDelete())
+                .securityValidator(headers -> validateHeaders(mcpTransportAuth, headers))
+                .build();
+    }
+
+    private static void validateHeaders(McpTransportAuth mcpTransportAuth, Map<String, List<String>> headers)
+            throws ServerTransportSecurityException {
+        try {
+            mcpTransportAuth.validateHeaders(headers);
+        } catch (ResultException e) {
+            throw toMcpSecurityException(e);
+        }
+    }
+
+    private static ServerTransportSecurityException toMcpSecurityException(ResultException e) {
+        var result = e.getResult();
+        Integer code = result == null ? null : result.getCode();
+        String message = result == null ? e.getMessage() : result.getMessage();
+        return new ServerTransportSecurityException(
+                code == null ? 403 : code,
+                message == null ? "登录已失效" : message
+        );
+    }
+
+    public static class McpTransportAuth {
+        @Auth(type = AuthType.API_KEY)
+        public void validateHeaders(Map<String, List<String>> headers) {
+        }
+    }
+}

--- a/ani-rss-application/src/main/resources/application.yaml
+++ b/ani-rss-application/src/main/resources/application.yaml
@@ -1,6 +1,13 @@
 spring:
   application:
     name: ani-rss-application
+  ai:
+    mcp:
+      server:
+        enabled: ${MCP_ENABLED:false}
+        protocol: streamable
+        streamable-http:
+          mcp-endpoint: /api/mcp
   web:
     resources:
       static-locations: classpath:/META-INF/dist

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -6,7 +6,7 @@ COPY ani-rss-application/target/ani-rss.jar /usr/app/ani-rss.jar
 WORKDIR /usr/app
 VOLUME /config
 ENV PUID=0 PGID=0 UMASK=022
-ENV SERVER_PORT=7789 CONFIG=/config TZ=Asia/Shanghai SWAGGER_ENABLED=false
+ENV SERVER_PORT=7789 CONFIG=/config TZ=Asia/Shanghai SWAGGER_ENABLED=false MCP_ENABLED=false
 EXPOSE $SERVER_PORT
 RUN sed -i 's/\r//g' /*.sh && chmod +x /*.sh
 CMD ["/exec.sh"]

--- a/pom.xml
+++ b/pom.xml
@@ -79,6 +79,13 @@
                 <artifactId>bittorrent</artifactId>
                 <version>0.3.0-v20070627-1030</version>
             </dependency>
+            <dependency>
+                <groupId>org.springframework.ai</groupId>
+                <artifactId>spring-ai-bom</artifactId>
+                <version>2.0.0-M6</version>
+                <type>pom</type>
+                <scope>import</scope>
+            </dependency>
         </dependencies>
     </dependencyManagement>
 


### PR DESCRIPTION
最近给 homeserver 配上了 agent，打算把 ani-rss 交给 agent 打理。虽然可以基于 swagger 直接生成 skill，但是仅靠 curl 感觉还是不太可靠，单独起个 cli 又太麻烦。

看到有 [issue](https://github.com/wushuo894/ani-rss/issues/638) / [disscusion](https://github.com/wushuo894/ani-rss/discussions/624) 都提到了 MCP 需求，所以就直接提 PR 了



改动如下：
- WebMvcConfig，自定义的 Gson 无法处理 MCP Message，所以目前先绕过了 MCP 包的 class
- MCPEndpointConfig，复用 Auth 逻辑，包装成的 MCP 消息格式
- AniMcpTools，一层 McpToolWrapper，目前仅暴露了搜索和添加订阅的能力
- endpoint 是 `/api/mcp`，添加 `MCP_ENABLED` env，默认关闭

不过也看到了 https://github.com/wushuo894/ani-rss/pull/660 被拒，不太确定还需不需要 MCP 了（不过还是提 PR 先😂


测试下来效果还行吧

<img width="405" height="410" alt="image" src="https://github.com/user-attachments/assets/4d45f8f1-95b4-40d9-8bab-f6c9cf42b8b1" />

<img width="810" height="753" alt="image" src="https://github.com/user-attachments/assets/3ccf44b6-b207-496f-8448-457f14c7a155" />
