### PR TITLE
feat: 添加全局的数据源开关

### DIFF
--- a/ani-rss-application/pom.xml
+++ b/ani-rss-application/pom.xml
@@ -24,11 +24,11 @@
         </repository>
         <repository>
             <id>ebml-reader</id>
-            <url>https://raw.github.com/wushuo894/EBMLReader/mvn-repo</url>
+            <url>https://raw.githubusercontent.com/wushuo894/EBMLReader/mvn-repo</url>
         </repository>
         <repository>
             <id>tmdb-api</id>
-            <url>https://raw.github.com/wushuo894/tmdb-api/mvn-repo</url>
+            <url>https://raw.githubusercontent.com/wushuo894/tmdb-api/mvn-repo</url>
         </repository>
     </repositories>
 

--- a/ani-rss-application/src/main/java/ani/rss/controller/BgmController.java
+++ b/ani-rss-application/src/main/java/ani/rss/controller/BgmController.java
@@ -30,6 +30,9 @@ public class BgmController extends BaseController {
     @Operation(summary = "搜索BGM条目")
     @PostMapping("/searchBgm")
     public Result<List<BgmInfo>> searchBgm(@RequestParam("name") String name) {
+        if (!Boolean.TRUE.equals(ConfigUtil.CONFIG.getBgmEnabled())) {
+            return Result.success(List.of());
+        }
         List<BgmInfo> search = BgmUtil.search(name);
         return Result.success(search);
     }
@@ -38,6 +41,9 @@ public class BgmController extends BaseController {
     @Operation(summary = "将指定id的BGM番剧转换为订阅")
     @PostMapping("/getAniBySubjectId")
     public Result<Ani> getAniBySubjectId(@RequestParam("id") String id) {
+        if (!Boolean.TRUE.equals(ConfigUtil.CONFIG.getBgmEnabled())) {
+            return Result.error("Bangumi 已禁用");
+        }
         BgmInfo bgmInfo = BgmUtil.getBgmInfo(id, true);
         Ani ani = BgmUtil.toAni(bgmInfo, AniUtil.createAni());
         ani
@@ -49,6 +55,9 @@ public class BgmController extends BaseController {
     @Operation(summary = "获取BGM标题")
     @PostMapping("/getBgmTitle")
     public Result<String> getBgmTitle(@RequestBody Ani ani) {
+        if (!Boolean.TRUE.equals(ConfigUtil.CONFIG.getBgmEnabled())) {
+            return Result.success(r -> r.setData(""));
+        }
         Tmdb tmdb = ani.getTmdb();
         BgmInfo bgmInfo = BgmUtil.getBgmInfo(ani);
         String finalName = BgmUtil.getFinalName(bgmInfo, tmdb);
@@ -59,6 +68,9 @@ public class BgmController extends BaseController {
     @Operation(summary = "获取评分")
     @PostMapping("/rate")
     public Result<Integer> rate(@RequestBody Ani ani) {
+        if (!Boolean.TRUE.equals(ConfigUtil.CONFIG.getBgmEnabled())) {
+            return Result.success(r -> r.setData(null));
+        }
         String subjectId = BgmUtil.getSubjectId(ani);
         Integer rate = BgmUtil.rate(subjectId, null);
         return Result.success(rate);
@@ -68,6 +80,9 @@ public class BgmController extends BaseController {
     @Operation(summary = "进行评分")
     @PostMapping("/setRate")
     public Result<Integer> setRate(@RequestBody Ani ani) {
+        if (!Boolean.TRUE.equals(ConfigUtil.CONFIG.getBgmEnabled())) {
+            return Result.error("Bangumi 已禁用");
+        }
         String subjectId = BgmUtil.getSubjectId(ani);
         Integer score = Opt.ofNullable(ani.getScore())
                 .map(Double::intValue)
@@ -81,6 +96,9 @@ public class BgmController extends BaseController {
     @Operation(summary = "获取当前BGM账号信息")
     @PostMapping("/meBgm")
     public Result<BgmMe> meBgm() {
+        if (!Boolean.TRUE.equals(ConfigUtil.CONFIG.getBgmEnabled())) {
+            return Result.error("Bangumi 已禁用");
+        }
         int expiresDays = BgmUtil.getExpiresDays();
         BgmMe me = BgmUtil.me();
         me.setExpiresDays(expiresDays);
@@ -91,6 +109,9 @@ public class BgmController extends BaseController {
     @Operation(summary = "BGM授权回调")
     @PostMapping("/bgm/oauth/callback")
     public Result<Void> callback(@RequestParam("code") String code) {
+        if (!Boolean.TRUE.equals(ConfigUtil.CONFIG.getBgmEnabled())) {
+            return Result.error("Bangumi 已禁用");
+        }
         Config config = ConfigUtil.CONFIG;
         String bgmAppID = config.getBgmAppID();
         String bgmAppSecret = config.getBgmAppSecret();

--- a/ani-rss-application/src/main/java/ani/rss/controller/ThemoviedbController.java
+++ b/ani-rss-application/src/main/java/ani/rss/controller/ThemoviedbController.java
@@ -5,6 +5,7 @@ import ani.rss.entity.Ani;
 import ani.rss.entity.web.Result;
 import ani.rss.entity.web.ResultCode;
 import ani.rss.util.other.TmdbUtils;
+import ani.rss.util.other.ConfigUtil;
 import cn.hutool.core.lang.Assert;
 import cn.hutool.core.util.StrUtil;
 import io.swagger.v3.oas.annotations.Operation;
@@ -23,6 +24,12 @@ public class ThemoviedbController extends BaseController {
     @Operation(summary = "获取TMDB标题")
     @PostMapping("/getThemoviedbName")
     public Result<Ani> getThemoviedbName(@RequestBody Ani ani) {
+        if (!Boolean.TRUE.equals(ConfigUtil.CONFIG.getTmdbEnabled())) {
+            return new Result<Ani>()
+                    .setCode(ResultCode.HTTP_INTERNAL_ERROR)
+                    .setMessage("TMDB 已禁用")
+                    .setData(ani.setThemoviedbName(""));
+        }
         String themoviedbName = TmdbUtils.getFinalName(ani);
         Result<Ani> result = new Result<Ani>()
                 .setCode(ResultCode.HTTP_OK)
@@ -39,6 +46,9 @@ public class ThemoviedbController extends BaseController {
     @Operation(summary = "获取TMDB剧集组")
     @PostMapping("/getThemoviedbGroup")
     public Result<List<TmdbGroup>> getThemoviedbGroup(@RequestBody Ani ani) {
+        if (!Boolean.TRUE.equals(ConfigUtil.CONFIG.getTmdbEnabled())) {
+            return Result.success(List.of());
+        }
         Tmdb tmdb = ani.getTmdb();
         Assert.notNull(tmdb, "tmdb is null");
         Assert.notBlank(tmdb.getId(), "tmdb is null");

--- a/ani-rss-application/src/main/java/ani/rss/entity/Config.java
+++ b/ani-rss-application/src/main/java/ani/rss/entity/Config.java
@@ -314,6 +314,18 @@ public class Config implements Serializable {
     private Boolean enabledExclude;
 
     /**
+     * BGM 总开关
+     */
+    @Schema(description = "BGM 总开关")
+    private Boolean bgmEnabled;
+
+    /**
+     * TMDB 总开关
+     */
+    @Schema(description = "TMDB 总开关")
+    private Boolean tmdbEnabled;
+
+    /**
      * BGM日语标题
      */
     @Schema(description = "BGM日语标题")

--- a/ani-rss-application/src/main/java/ani/rss/service/ScrapeService.java
+++ b/ani-rss-application/src/main/java/ani/rss/service/ScrapeService.java
@@ -79,6 +79,9 @@ public class ScrapeService {
      * @throws Exception
      */
     public void scrapeMovie(Ani ani, Boolean force) throws Exception {
+        if (!Boolean.TRUE.equals(ConfigUtil.CONFIG.getTmdbEnabled())) {
+            return;
+        }
         Tmdb tmdb = ani.getTmdb();
 
         // 更新tmdb信息
@@ -156,6 +159,9 @@ public class ScrapeService {
      * @throws Exception
      */
     public void scrapeTv(Ani ani, Boolean force) throws Exception {
+        if (!Boolean.TRUE.equals(ConfigUtil.CONFIG.getTmdbEnabled())) {
+            return;
+        }
         Tmdb tmdb = ani.getTmdb();
 
         // 更新tmdb信息
@@ -342,6 +348,9 @@ public class ScrapeService {
      */
     public void saveBangumiIni(Ani ani, Boolean force) {
         Config config = ConfigUtil.CONFIG;
+        if (!Boolean.TRUE.equals(config.getBgmEnabled())) {
+            return;
+        }
         Boolean bangumiIniEnabled = config.getBangumiIniEnabled();
         if (!bangumiIniEnabled) {
             // 未开启 bangumi.ini

--- a/ani-rss-application/src/main/java/ani/rss/task/BgmTask.java
+++ b/ani-rss-application/src/main/java/ani/rss/task/BgmTask.java
@@ -29,6 +29,11 @@ public class BgmTask implements BaseTask {
 
     @Override
     public void accept(AtomicBoolean loop) {
+        if (!Boolean.TRUE.equals(ConfigUtil.CONFIG.getBgmEnabled())) {
+            ThreadUtil.sleep(12, TimeUnit.HOURS);
+            return;
+        }
+
         try {
             BgmUtil.refreshToken();
         } catch (Exception e) {

--- a/ani-rss-application/src/main/java/ani/rss/util/other/AniUtil.java
+++ b/ani-rss-application/src/main/java/ani/rss/util/other/AniUtil.java
@@ -178,13 +178,13 @@ public class AniUtil {
         String bgmUrl = ani.getBgmUrl();
         String subgroup = ani.getSubgroup();
 
-        Assert.notBlank(bgmUrl, "bgmUrl 不能为空");
-
-        BgmInfo bgmInfo = BgmUtil.getBgmInfo(ani, true);
-
-        BgmUtil.toAni(bgmInfo, ani);
-
         Config config = ConfigUtil.CONFIG;
+
+        if (Boolean.TRUE.equals(config.getBgmEnabled())) {
+            Assert.notBlank(bgmUrl, "bgmUrl 不能为空");
+            BgmInfo bgmInfo = BgmUtil.getBgmInfo(ani, true);
+            BgmUtil.toAni(bgmInfo, ani);
+        }
 
         // 只下载最新集
         Boolean downloadNew = config.getDownloadNew();

--- a/ani-rss-application/src/main/java/ani/rss/util/other/BgmUtil.java
+++ b/ani-rss-application/src/main/java/ani/rss/util/other/BgmUtil.java
@@ -30,6 +30,8 @@ import com.google.gson.JsonObject;
 import lombok.extern.slf4j.Slf4j;
 import wushuo.tmdb.api.entity.Tmdb;
 
+import java.net.ConnectException;
+import java.net.SocketTimeoutException;
 import java.util.*;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.TimeUnit;
@@ -491,11 +493,19 @@ public class BgmUtil {
         if (!isCache) {
             // 不使用缓存
             HttpRequest httpRequest = HttpReq.get(bgmApi + "/v0/subjects/" + subjectId);
-            return setToken(httpRequest).thenFunction(fun);
+            try {
+                return setToken(httpRequest).thenFunction(fun);
+            } catch (Exception e) {
+                if (isNetworkException(e)) {
+                    throw new IllegalArgumentException("Bangumi 网络连接超时, 请检查网络或代理设置");
+                }
+                throw e;
+            }
         }
 
         AtomicReference<BgmInfo> bgmInfoAR = new AtomicReference<>();
         AtomicReference<BgmInfo> bgmInfoCacheAR = new AtomicReference<>();
+        AtomicReference<Boolean> networkTimeout = new AtomicReference<>(false);
 
         // 并行获取bgm信息
         CompletableFuture.allOf(
@@ -507,6 +517,9 @@ public class BgmUtil {
                                 .thenFunction(fun);
                         bgmInfoAR.set(bgmInfo);
                     } catch (Exception e) {
+                        if (isNetworkException(e)) {
+                            networkTimeout.set(true);
+                        }
                         log.error(e.getMessage(), e);
                     }
                 }),
@@ -526,6 +539,9 @@ public class BgmUtil {
 
         bgmInfo = ObjectUtil.defaultIfNull(bgmInfo, bgmInfoCacheAR.get());
 
+        if (Objects.isNull(bgmInfo) && Boolean.TRUE.equals(networkTimeout.get())) {
+            throw new IllegalArgumentException("Bangumi 网络连接超时, 请检查网络或代理设置");
+        }
         Assert.notNull(bgmInfo, "获取 bgmInfo 失败!");
 
         return bgmInfo;
@@ -883,5 +899,15 @@ public class BgmUtil {
                 .setCustomCompletedPathTemplate(completedPathTemplate);
     }
 
+    private static boolean isNetworkException(Throwable e) {
+        Throwable cause = e;
+        while (cause != null) {
+            if (cause instanceof SocketTimeoutException || cause instanceof ConnectException) {
+                return true;
+            }
+            cause = cause.getCause();
+        }
+        return false;
+    }
 
 }

--- a/ani-rss-application/src/main/java/ani/rss/util/other/ConfigUtil.java
+++ b/ani-rss-application/src/main/java/ani/rss/util/other/ConfigUtil.java
@@ -164,6 +164,8 @@ public class ConfigUtil {
                 .setExclude(List.of("720[Pp]", "\\d-\\d", "合集", "特别篇"))
                 .setImportExclude(false)
                 .setEnabledExclude(false)
+                .setBgmEnabled(true)
+                .setTmdbEnabled(true)
                 .setTmdb(false)
                 .setBgmJpName(false)
                 .setTmdbId(false)

--- a/ani-rss-ui/src/config/Basic.vue
+++ b/ani-rss-ui/src/config/Basic.vue
@@ -18,7 +18,7 @@
     <el-collapse-item name="trackers" title="Trackers">
       <trackers :config="props.config"/>
     </el-collapse-item>
-    <el-collapse-item name="bangumi" title="Bangumi">
+    <el-collapse-item v-if="props.config['bgmEnabled']" name="bangumi" title="Bangumi">
       <bangumi :config="props.config"/>
     </el-collapse-item>
     <el-collapse-item name="other" title="其他">

--- a/ani-rss-ui/src/config/basic/Add.vue
+++ b/ani-rss-ui/src/config/basic/Add.vue
@@ -10,61 +10,63 @@
     <el-form-item label="自动剧集偏移">
       <el-switch v-model:model-value="props.config.offset"/>
     </el-form-item>
-    <el-form-item label="BGM日语标题">
+    <el-form-item v-if="props.config['bgmEnabled']" label="BGM日语标题">
       <el-switch v-model:model-value="props.config['bgmJpName']"/>
     </el-form-item>
-    <el-form-item label="TMDB ID">
-      <div>
-        <el-switch v-model="props.config.tmdbId"/>
-        <br>
-        <el-checkbox
-            :disabled="!props.config.tmdbId"
-            v-model="props.config.tmdbIdPlexMode"
-            label="Plex Mode"
-        />
-        <br>
-        <el-text class="mx-1" size="small">
-          自动获取tmdbId, 如: 女仆冥土小姐。 [tmdbid=242143]
-        </el-text>
-      </div>
-    </el-form-item>
-    <el-form-item label="TMDB标题">
-      <div>
-        <el-switch v-model:model-value="props.config.tmdb"/>
-        <br>
-        <el-text class="mx-1" size="small">
-          自动使用TMDB的标题
-        </el-text>
-        <br>
-        <el-checkbox v-model="props.config['tmdbAnime']" label="仅获取动漫"/>
-      </div>
-    </el-form-item>
-    <el-form-item label="TMDB语言">
-      <div>
+    <template v-if="props.config['tmdbEnabled']">
+      <el-form-item label="TMDB ID">
         <div>
-          <el-select v-model:model-value="props.config['tmdbLanguage']" class="width-150">
-            <el-option v-for="item in tmdb_i18n" :value="item.i18n_tag"
-                       :label="`${item.native_name} (${item.i18n_tag})`"
-                       :key="item.i18n_tag">
-              <span class="float-left">{{ item.native_name }}</span>
-              <el-text type="info" class="float-right" size="small">
-                {{ item.i18n_tag }}
-              </el-text>
-            </el-option>
-          </el-select>
+          <el-switch v-model="props.config.tmdbId"/>
+          <br>
+          <el-checkbox
+              :disabled="!props.config.tmdbId"
+              v-model="props.config.tmdbIdPlexMode"
+              label="Plex Mode"
+          />
+          <br>
+          <el-text class="mx-1" size="small">
+            自动获取tmdbId, 如: 女仆冥土小姐。 [tmdbid=242143]
+          </el-text>
         </div>
+      </el-form-item>
+      <el-form-item label="TMDB标题">
         <div>
-          <el-checkbox v-model="props.config['tmdbRomaji']" label="优先获取罗马音"/>
+          <el-switch v-model:model-value="props.config.tmdb"/>
+          <br>
+          <el-text class="mx-1" size="small">
+            自动使用TMDB的标题
+          </el-text>
+          <br>
+          <el-checkbox v-model="props.config['tmdbAnime']" label="仅获取动漫"/>
         </div>
-      </div>
-    </el-form-item>
+      </el-form-item>
+      <el-form-item label="TMDB语言">
+        <div>
+          <div>
+            <el-select v-model:model-value="props.config['tmdbLanguage']" class="width-150">
+              <el-option v-for="item in tmdb_i18n" :value="item.i18n_tag"
+                         :label="`${item.native_name} (${item.i18n_tag})`"
+                         :key="item.i18n_tag">
+                <span class="float-left">{{ item.native_name }}</span>
+                <el-text type="info" class="float-right" size="small">
+                  {{ item.i18n_tag }}
+                </el-text>
+              </el-option>
+            </el-select>
+          </div>
+          <div>
+            <el-checkbox v-model="props.config['tmdbRomaji']" label="优先获取罗马音"/>
+          </div>
+        </div>
+      </el-form-item>
+    </template>
     <el-form-item label="开启全局排除">
       <el-switch v-model:model-value="props.config.enabledExclude" :disabled="props.config.importExclude"/>
     </el-form-item>
     <el-form-item label="导入全局排除">
       <el-switch v-model:model-value="props.config.importExclude" :disabled="props.config.enabledExclude"/>
     </el-form-item>
-    <el-form-item label="封面质量">
+    <el-form-item v-if="props.config['bgmEnabled']" label="封面质量">
       <el-select v-model="props.config['bgmImage']" class="width-150">
         <el-option v-for="item in ['small','grid','large','medium','common']" :key="item"
                    :value="item"></el-option>

--- a/ani-rss-ui/src/config/basic/Scrape.vue
+++ b/ani-rss-ui/src/config/basic/Scrape.vue
@@ -1,14 +1,22 @@
 <template>
   <el-form @submit.prevent label-width="auto"
            class="full-width">
+    <el-alert v-if="!props.config['bgmEnabled'] && !props.config['tmdbEnabled']"
+              type="error"
+              show-icon
+              :closable="false"
+              class="scrape-alert">
+      所有数据源已关闭，将不会执行刮削，仅按规则进行重命名和下载
+    </el-alert>
     <el-form-item label="自动刮削">
-      <el-switch v-model="props.config['scrape']"/>
+      <el-switch v-model="props.config['scrape']"
+                 :disabled="!props.config['bgmEnabled'] && !props.config['tmdbEnabled']"/>
     </el-form-item>
     <el-form-item label="Bangumi">
-      <el-switch v-model="props.config['bgmEnabled']"/>
+      <el-switch v-model="props.config['bgmEnabled']" @change="onDataSourceChange"/>
     </el-form-item>
     <el-form-item label="TMDB">
-      <el-switch v-model="props.config['tmdbEnabled']"/>
+      <el-switch v-model="props.config['tmdbEnabled']" @change="onDataSourceChange"/>
     </el-form-item>
     <el-form-item label="追更天数">
       <div>
@@ -45,4 +53,18 @@
 import {ElText} from "element-plus";
 
 let props = defineProps(['config'])
+
+let onDataSourceChange = () => {
+  if (!props.config['bgmEnabled'] && !props.config['tmdbEnabled']) {
+    props.config['scrape'] = false
+  } else {
+    props.config['scrape'] = true
+  }
+}
 </script>
+
+<style scoped>
+.scrape-alert {
+  margin-bottom: 16px;
+}
+</style>

--- a/ani-rss-ui/src/config/basic/Scrape.vue
+++ b/ani-rss-ui/src/config/basic/Scrape.vue
@@ -4,6 +4,12 @@
     <el-form-item label="自动刮削">
       <el-switch v-model="props.config['scrape']"/>
     </el-form-item>
+    <el-form-item label="Bangumi">
+      <el-switch v-model="props.config['bgmEnabled']"/>
+    </el-form-item>
+    <el-form-item label="TMDB">
+      <el-switch v-model="props.config['tmdbEnabled']"/>
+    </el-form-item>
     <el-form-item label="追更天数">
       <div>
         <el-input-number v-model="props.config['followDay']" :min="1">
@@ -17,18 +23,20 @@
         </el-text>
       </div>
     </el-form-item>
-    <el-form-item label="更多">
+    <el-form-item v-if="props.config['bgmEnabled']" label="更多">
       <el-checkbox label="bangumi.ini" v-model="props.config['bangumiIniEnabled']"/>
     </el-form-item>
-    <el-form-item label="TmdbApi">
-      <el-input v-model:model-value="props.config['tmdbApi']" placeholder="https://api.themoviedb.org"/>
-    </el-form-item>
-    <el-form-item label="TmdbApiKey">
-      <el-input v-model:model-value="props.config['tmdbApiKey']" placeholder="请自备 API 密钥, 留空使用系统默认"/>
-    </el-form-item>
-    <el-form-item label="TmdbImage">
-      <el-input v-model:model-value="props.config['tmdbImage']" placeholder="https://image.tmdb.org"/>
-    </el-form-item>
+    <template v-if="props.config['tmdbEnabled']">
+      <el-form-item label="TmdbApi">
+        <el-input v-model:model-value="props.config['tmdbApi']" placeholder="https://api.themoviedb.org"/>
+      </el-form-item>
+      <el-form-item label="TmdbApiKey">
+        <el-input v-model:model-value="props.config['tmdbApiKey']" placeholder="请自备 API 密钥, 留空使用系统默认"/>
+      </el-form-item>
+      <el-form-item label="TmdbImage">
+        <el-input v-model:model-value="props.config['tmdbImage']" placeholder="https://image.tmdb.org"/>
+      </el-form-item>
+    </template>
   </el-form>
 </template>
 

--- a/ani-rss-ui/src/home/Ani.vue
+++ b/ani-rss-ui/src/home/Ani.vue
@@ -14,12 +14,14 @@
               <el-input v-model:model-value="props.ani.title" class="full-width"/>
             </div>
             <div class="change-title-button">
-              <el-button :loading="getBgmNameLoading"
+              <el-button v-if="globalConfig['bgmEnabled']"
+                         :loading="getBgmNameLoading"
                          bg
                          icon="DocumentAdd" text @click="getBgmName">
                 使用Bangumi
               </el-button>
-              <el-button @click="props.ani.title = ani.themoviedbName"
+              <el-button v-if="globalConfig['tmdbEnabled']"
+                         @click="props.ani.title = ani.themoviedbName"
                          icon="DocumentAdd"
                          :disabled="props.ani.title === ani.themoviedbName || !ani.themoviedbName.length" bg text>
                 使用TMDB
@@ -27,7 +29,7 @@
             </div>
           </div>
         </el-form-item>
-        <el-form-item label="TMDB">
+        <el-form-item v-if="globalConfig['tmdbEnabled']" label="TMDB">
           <div class="flex full-width" style="justify-content: space-between;">
             <div class="el-input is-disabled">
               <div class="el-input__wrapper" tabindex="-1"
@@ -45,7 +47,7 @@
             <el-button icon="Refresh" bg text @click="getThemoviedbName" :loading="getThemoviedbNameLoading"/>
           </div>
         </el-form-item>
-        <el-form-item v-if="!props.ani.ova && props.ani.tmdb" label="剧集组">
+        <el-form-item v-if="globalConfig['tmdbEnabled'] && !props.ani.ova && props.ani.tmdb" label="剧集组">
           <div class="tmdb-group">
             <el-input v-model="props.ani.tmdb['tmdbGroupId']" placeholder="留空不使用剧集组"/>
             <div style="width: 4px;"/>
@@ -306,6 +308,9 @@ import * as http from "@/js/http.js";
 import {getBgmTitle} from "@/js/http.js";
 import AniBT from "@/home/AniBT.vue";
 import AnimeGarden from "@/home/AnimeGarden.vue";
+import {configData} from "@/js/config.js";
+
+const globalConfig = ref(configData)
 
 const aniBTRef = ref()
 const mikanRef = ref()
@@ -341,6 +346,9 @@ let match = ref()
 
 onMounted(() => {
   init()
+  http.config().then(res => {
+    globalConfig.value = res.data
+  })
 })
 
 let scrollbarRef = ref()

--- a/ani-rss-ui/src/home/Collection.vue
+++ b/ani-rss-ui/src/home/Collection.vue
@@ -22,12 +22,14 @@
                              @click="bgmRef?.show(data.ani.title)"/>
                 </div>
                 <div v-if="data.show" class="change-title-button">
-                  <el-button :loading="getBgmNameLoading"
+                  <el-button v-if="globalConfig['bgmEnabled']"
+                             :loading="getBgmNameLoading"
                              bg
                              icon="DocumentAdd" text @click="getBgmName">
                     使用Bangumi
                   </el-button>
-                  <el-button :disabled="data.ani.title === data.ani.themoviedbName || !data.ani.themoviedbName.length"
+                  <el-button v-if="globalConfig['tmdbEnabled']"
+                             :disabled="data.ani.title === data.ani.themoviedbName || !data.ani.themoviedbName.length"
                              bg
                              icon="DocumentAdd"
                              text
@@ -38,7 +40,7 @@
               </div>
             </el-form-item>
             <template v-if="data.show">
-              <el-form-item label="TMDB">
+              <el-form-item v-if="globalConfig['tmdbEnabled']" label="TMDB">
                 <div class="flex full-width" style="justify-content: space-between;">
                   <div class="el-input is-disabled">
                     <div class="el-input__wrapper"
@@ -192,7 +194,7 @@
 </template>
 
 <script setup>
-import {ref} from "vue";
+import {onMounted, ref} from "vue";
 import {UploadFilled} from "@element-plus/icons-vue";
 import {ElMessage, ElMessageBox} from "element-plus";
 import Bgm from "./Bgm.vue";
@@ -203,6 +205,15 @@ import {aniData} from "@/js/ani.js";
 import {authorization} from "@/js/global.js";
 import * as http from "@/js/http.js";
 import {getBgmTitle} from "@/js/http.js";
+import {configData} from "@/js/config.js";
+
+const globalConfig = ref(configData)
+
+onMounted(() => {
+  http.config().then(res => {
+    globalConfig.value = res.data
+  })
+})
 
 let start = () => {
   startLoading.value = true

--- a/ani-rss-ui/src/js/config.js
+++ b/ani-rss-ui/src/js/config.js
@@ -57,6 +57,8 @@ export let configData = {
     "importExclude": false,
     "enabledExclude": false,
     "bgmJpName": false,
+    "bgmEnabled": true,
+    "tmdbEnabled": true,
     "tmdb": false,
     "tmdbId": false,
     "tmdbIdPlexMode": false,


### PR DESCRIPTION
目前版本（3.1.47）在没有使用代理的情况下，根据网络环境的不同可能在创建刮削的情况下出现网络异常，类似于此类
```shell
2026-06-09 10:59:20 ERROR [ForkJoinPool.commonPool-worker-3] ani.rss.util.other.BgmUtil - SocketTimeoutException: Connect timed out
2026-06-09 10:59:42 ERROR [http-nio-0.0.0.0-7789-exec-1] ani.rss.util.basic.HttpRequestPlus - url: https://api.bgm.tv/v0/episodes, error: 网络连接超时
2026-06-09 10:59:42 ERROR [http-nio-0.0.0.0-7789-exec-1] ani.rss.util.other.BgmUtil - SocketTimeoutException: Connect timed out
2026-06-09 11:00:02 ERROR [http-nio-0.0.0.0-7789-exec-1] ani.rss.util.basic.HttpRequestPlus - url: https://lain.bgm.tv/pic/cover/l/93/8f/535669_4zoHG.jpg, error: 网络连接超时
2026-06-09 11:00:02 ERROR [http-nio-0.0.0.0-7789-exec-1] ani.rss.util.other.AniUtil - SocketTimeoutException: Connect timed out
2026-06-09 11:03:39 ERROR [http-nio-0.0.0.0-7789-exec-1] ani.rss.util.basic.HttpRequestPlus - url: https://bgm.tv/oauth/token_status, error: 网络连接超时
```
并且在创建新的订阅的时候，如果蜜柑或者AniGT的返回值里写了BgmUrl，则会强制去访问一次Bgm，如果此时网络不通则会产生业务中断，且UI上并没有错误提示静默失败

 - 添加 Bangumi 和 TMDB 全局开关，允许用户独立启用/禁用两个数据源，前端设置页适配开关控制
 - 关闭 BGM 时跳过添加订阅流程中的 BGM 信息获取
 - BGM 网络不可达时，前端显示明确的超时提示替代原先的静默失败
 - 修复 GitHub Raw 仓库地址，修改为官方推荐的更标准的`raw.githubusercontent.com`