### PR TITLE
Upgrade to Java 21

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -17,7 +17,7 @@
 
     <packaging>pom</packaging>
     <properties>
-        <java.version>17</java.version>
+        <java.version>21</java.version>
     </properties>
 
     <modules>
@@ -100,7 +100,7 @@
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-compiler-plugin</artifactId>
                 <configuration>
-                    <release>17</release>
+                    <release>${java.version}</release>
                     <encoding>UTF-8</encoding>
                     <parameters>true</parameters>
                     <annotationProcessorPaths>


### PR DESCRIPTION
Upgrades the build from Java 17 to Java 21 (LTS).

- `pom.xml`: `<java.version>` 17 → 21, and the compiler `<release>` now references `${java.version}` instead of a hard-coded value

**Verification:** the project compiles under JDK 21 and its tests pass, with none lost versus the JDK-17 baseline. No production or test code was changed — only the compiler target.



---
### How this was produced
This change was produced by running the OpenRewrite recipe below — the committed diff is the recipe output (no hand-editing):

```yaml
# rewrite.yml
type: specs.openrewrite.org/v1beta/recipe
name: com.example.UpgradeJava
recipeList:
  - org.openrewrite.java.migrate.UpgradePluginsForJava21
  - org.openrewrite.java.migrate.UpgradeBuildToJava21
  - org.openrewrite.java.migrate.UpgradeJavaVersion:
      version: 21
```
```bash
mvn -U org.openrewrite.maven:rewrite-maven-plugin:RELEASE:run \
  -Drewrite.configLocation=$(pwd)/rewrite.yml \
  -Drewrite.activeRecipes=com.example.UpgradeJava \
  -Drewrite.recipeArtifactCoordinates=org.openrewrite.recipe:rewrite-migrate-java:RELEASE
```

_Verified: all 2 tests pass under JDK 21, none lost versus the baseline._
