### PR TITLE
fix: 修复 Transmission 添加种子任务时未设置暂停状态

### DIFF
--- a/ani-rss-application/src/main/java/ani/rss/entity/torrent/TransmissionRpcBody.java
+++ b/ani-rss-application/src/main/java/ani/rss/entity/torrent/TransmissionRpcBody.java
@@ -43,6 +43,7 @@ public class TransmissionRpcBody implements Serializable {
         params.put("download_dir", downloadDir);
         params.put("metainfo", Base64.encode(torrent));
         params.put("filename", "");
+        params.put("paused", false);
         return transmissionRpcBody;
     }
 
@@ -53,6 +54,7 @@ public class TransmissionRpcBody implements Serializable {
         params.put("download_dir", downloadDir);
         params.put("metainfo", "");
         params.put("filename", magnet);
+        params.put("paused", false);
         return transmissionRpcBody;
     }
 


### PR DESCRIPTION
https://github.com/wushuo894/ani-rss/blob/v3.1.74/ani-rss-application/src/main/resources/transmission/torrent-add.json#L7