### PR TITLE
fix(ui): use downloaded status field in preview

### DIFF
--- a/ani-rss-ui/src/home/Preview.vue
+++ b/ani-rss-ui/src/home/Preview.vue
@@ -15,7 +15,7 @@
         <el-button bg text :disabled="!selectViews.length" @click="allowDownload" icon="Check" type="primary">允许下载
         </el-button>
         <el-button bg text :disabled="!selectViews.length" @click="notDownload" icon="Close">禁止下载</el-button>
-        <popconfirm @confirm="delTorrent" :title="`删除${selectViews.filter(it => it.local).length}个种子缓存?`">
+        <popconfirm @confirm="delTorrent" :title="`删除${selectViews.filter(it => it['hasDownloaded']).length}个种子缓存?`">
           <template #reference>
             <el-button icon="Remove" bg text type="danger"
                        :disabled="!selectViews.filter(it => it['hasDownloaded']).length">
@@ -123,11 +123,11 @@ const selectItems = ref([
   },
   {
     label: '本地已存在',
-    fun: it => it.local
+    fun: it => it['hasDownloaded']
   },
   {
     label: '本地不存在',
-    fun: it => !it.local
+    fun: it => !it['hasDownloaded']
   }
 ])
 const dialogVisible = ref(false)
@@ -175,7 +175,7 @@ let load = () => {
 }
 
 let delTorrent = () => {
-  let infoHash = selectViews.value.filter(it => it['local']).map(it => it['infoHash']).join(",")
+  let infoHash = selectViews.value.filter(it => it['hasDownloaded']).map(it => it['infoHash']).join(",")
   http.deleteTorrent(props.ani.id, infoHash)
       .then(res => {
         ElMessage.success(res.message)


### PR DESCRIPTION
## 修改内容

- 将预览页残留的 `local` 字段引用改为后端实际返回的 `hasDownloaded`
- 修正“本地已存在/不存在”筛选条件
- 修正删除种子时的确认数量及待删除项过滤

## 原因

后端 `Item` 使用 `hasDownloaded` 表示资源是否已下载，但预览页部分逻辑仍读取旧的 `local` 字段，导致筛选和删除种子功能无法正确判断本地状态。

## 影响

预览页现在能正确筛选已下载资源，并只对实际已下载的资源执行种子删除。

## 验证

- `pnpm build`
