### PR TITLE
fix: include credentials when loading web manifest

### DIFF
--- a/ani-rss-ui/index.html
+++ b/ani-rss-ui/index.html
@@ -4,7 +4,7 @@
     <meta charset="UTF-8"/>
     <title>ANI-RSS</title>
     <link rel="icon" href="/favicon.ico"/>
-    <link rel="manifest" href="/manifest.json"/>
+    <link rel="manifest" href="/manifest.json" crossorigin="use-credentials"/>
     <meta name="viewport"
           content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=0, viewport-fit=cover">
     <meta name="theme-color" id="themeColorMeta" content="#ffffff">


### PR DESCRIPTION
### 问题

当 ANI-RSS 部署在需要认证的 Forward Auth / Forward Proxy 后面时（例如 Authentik），浏览器加载 `/manifest.json` 可能会失败。

未指定 `crossorigin="use-credentials"` 时，Web App Manifest 请求不会携带认证所需的 credentials。认证代理因此会将 `/manifest.json` 重定向到登录页面。

例如：

```text
/manifest.json
  -> 302 https://sso.example.com/authorize/...
  -> blocked by CORS
```

浏览器最终会报告类似：

```text
Access to manifest ... has been blocked by CORS policy
```

这看起来像是 CORS 问题，但实际原因是 manifest 请求没有携带认证凭据。

### 修改

将：

```html
<link rel="manifest" href="/manifest.json"/>
```

修改为：

```html
<link rel="manifest" href="/manifest.json" crossorigin="use-credentials"/>
```

根据 Web App Manifest 的加载规则，如果 manifest 需要携带 credentials，即使 manifest 与页面同源，也需要显式指定 `crossorigin="use-credentials"`。

参考：

https://developer.mozilla.org/en-US/docs/Web/HTML/Reference/Attributes/crossorigin

### 影响

* 修复 Forward Auth / Forward Proxy 环境下 manifest 加载失败的问题
* 不需要将 `/manifest.json` 排除在认证之外
* 对不使用认证代理的普通部署没有行为上的负面影响
